### PR TITLE
Solr image generation using GHA

### DIFF
--- a/.github/workflows/solr.yml
+++ b/.github/workflows/solr.yml
@@ -1,0 +1,60 @@
+name: Solr image creation
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - ".github/workflows/solr.yml"
+      - "solr/**"
+
+env:
+    IMAGE_NAME: ghcr.io/kitconcept/solr
+
+jobs:
+
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: |
+            ${{ env.IMAGE_NAME }}
+          flavor:
+            latest=false
+          tags: |
+            type=ref,event=branch
+            type=sha
+            type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to Container Registry
+        uses: docker/login-action@v2
+        with:
+            registry: ghcr.io
+            username: ${{ github.actor }}
+            password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v3
+        with:
+          platforms: linux/amd64,linux/arm64
+          context: solr
+          file: solr/Dockerfile
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/solr/Dockerfile
+++ b/solr/Dockerfile
@@ -2,8 +2,9 @@
 FROM solr:8
 
 LABEL maintainer="kitconcept, GmbH <info@kitconcept.com>" \
-      org.label-schema.name="kitconcept-internet-solr" \
-      org.label-schema.description="KitConcept Solr installation" \
+      org.label-schema.name="ghcr.io/kitconcept/solr" \
+      org.label-schema.description="Solr 8 image with Plone default settings" \
       org.label-schema.vendor="kitconcept, GmbH"
 
+# Copy default plone configuration for this image
 COPY etc /plone-config


### PR DESCRIPTION
# Summary

- [X] GHA to build and publish a Solr image named `ghcr.io/kitconcept/solr`
- [X] Build images for `linux/amd64` and `linux/arm64` (It will take more time, but it is a better solution for public images)

# Issue
Closes #3 