### PR TITLE
Revamp solr configuration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,9 +18,9 @@ YELLOW=`tput setaf 3`
 BACKEND_FOLDER=$(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 GIT_FOLDER=$(BACKEND_FOLDER)/.git
 
-COMPOSE_PROJECT_NAME=kitconcept.solr
-SOLR_DATA_FOLDER?=${CURRENT_DIR}/data
-SOLR_ONLY_COMPOSE?=${CURRENT_DIR}/docker-compose.yml
+COMPOSE_PROJECT_NAME=kitconcept_solr
+SOLR_DATA_FOLDER?=${BACKEND_FOLDER}/data
+SOLR_ONLY_COMPOSE?=${BACKEND_FOLDER}/docker-compose.yml
 
 # Python checks
 PYTHON?=python3

--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@
 [![PyPI - License](https://img.shields.io/pypi/l/kitconcept.solr)](https://pypi.org/project/kitconcept.solr/)
 [![PyPI - Status](https://img.shields.io/pypi/status/kitconcept.solr)](https://pypi.org/project/kitconcept.solr/)
 
-
 [![PyPI - Plone Versions](https://img.shields.io/pypi/frameworkversions/plone/kitconcept.solr)](https://pypi.org/project/kitconcept.solr/)
 
 [![Meta](https://github.com/kitconcept/kitconcept.solr/actions/workflows/meta.yml/badge.svg)](https://github.com/kitconcept/kitconcept.solr/actions/workflows/meta.yml)
@@ -30,9 +29,17 @@
 
 ### Endpoints
 
-| name | context |
-| -- | -- |
+| name    | context                         |
+| ------- | ------------------------------- |
 | `@solr` | Plone site or Folderish content |
+
+#### Using the `@solr` endpoint
+
+The `@solr` endpoint is used from the `kitconcept.volto-solr` Volto add-on package for the implementation of the site search. It can also be used for custom components. The parameters roughly follow the parameters of the normal site search service, but differ in some respects.
+
+**TBD** _give more information about this._
+
+For now, please refer to the source code of the `solr.py` module, in case you want to use for your own purposes.
 
 ## Documentation
 
@@ -74,8 +81,8 @@ You can create an issue in the issue tracker, or contact a maintainer.
 
 ### Development requirements
 
-* Python 3.8 or later
-* Docker
+- Python 3.8 or later
+- Docker
 
 ### Setup
 
@@ -91,24 +98,115 @@ By default, we use the latest Plone version in the 6.x series.
 
 Most of the development configuration is managed with [`plone.meta`](https://github.com/plone/plone.meta), so avoid manually editing the following files:
 
-* `.editorconfig`
-* `.flake8`
-* `.gitignore`
-* `.pre-commit-config.yaml`
-* `news/.changelog_template.jinja`
-* `pyproject.toml`
-* `tox.ini`
+- `.editorconfig`
+- `.flake8`
+- `.gitignore`
+- `.pre-commit-config.yaml`
+- `news/.changelog_template.jinja`
+- `pyproject.toml`
+- `tox.ini`
+
+In addition there is Solr related configuration that is outlined in the following chapters.
+
+#### Configuring Solr
+
+Solr is configured by a default configuration that can be found in the [`/solr/etc/`](./solr/etc) folder in this repository. This contains, most notably, the `schema.xml` that defines the indexes for Solr. This package also builds docker images with the default Solr version, set up with this default configuration.
+
+If you need to customize the Solr configuration (such as adding new indexes, etc.) then you should copy the `solr` folder into your own project, customize it as you wish, and then build your own docker images (or compile your own Solr server) based on this configuration.
+
+A typical use case for why you would want to do this, is if you add new fields to some content types, and you want to render the values for these additional fields in the search results. In this case you want to add the additional fields as indexes to Solr. You probably would not need this, unless you change anything on the result type templates in the `kitconcept.volto-solr` front-end package.
+
+#### Configuring the front-end and back-end packages
+
+The package supports the usage of the `kitconcept.volto-solr` add-on, and it is designed to be used together with it.
+
+The configuration can be specified in a customized way. Without any additional configuration, the package will use the default, which is specified in json format in the [`kitconcept.solr.interfaces.IKitconceptSolrSettings`](./src/kitconcept/solr/profiles/default/registry/kitconcept.solr.interfaces.IKitconceptSolrSettings.xml) registry.
+
+This configuration settings affect the behavior of both the `kitconcept.solr` (this) back-end package, and the `kitconcept.volto-solr` front-end package (a Volto add-on). In addition, `kitconcept.volto-solr` has its own Volto add-on configuration which is not explained here, for these options please refer to the documentation of the add-on package.
+
+##### Configuration options
+
+Explanation for the configuration options:
+
+###### `fieldList`
+
+Contains the fields that solr should return. If the search result templates in the volto add-on are modified, and require more fields than in the default list, the fields **must explicitly be added** here.
+
+In addition, the same fields must be present in the Solr index - if either the Solr index or the field in `fieldList` is missing, the field value will silently be not returned. No error will be shown.
+
+Example value:
+
+```json
+[
+  "UID",
+  "Title",
+  "Description",
+  "Type",
+  "effective",
+  "start",
+  "created",
+  "end",
+  "path_string",
+  "mime_type",
+  "phone",
+  "email",
+  "location",
+  "image_scales",
+  "image_field"
+]
+```
+
+###### `searchTabs`
+
+A list of dictionary items representing the facet tabs in the search page.
+
+The `label` field specifies the label to be shown on the tab in English. It's the front-end package's responsibility to provide translations for this, as `kitconcept.volto-solr` does this for the defaults, which can be used as an example.
+
+The `filter` field defines the Solr search condition to the given facet tab. This can be a content type, or in fact any condition understood by Solr, please consult the Solr documentation for more details.
+
+Example value:
+
+```json
+[
+  {
+    "label": "All",
+    "filter": "Type(*)"
+  },
+  {
+    "label": "Pages",
+    "filter": "Type:(Page)"
+  },
+  {
+    "label": "Events",
+    "filter": "Type:(Event)"
+  },
+  {
+    "label": "Images",
+    "filter": "Type:(Image)"
+  },
+  {
+    "label": "Files",
+    "filter": "Type:(File)"
+  }
+]
+```
+
+##### Overriding the configuration options
+
+If needed, the default [`kitconcept.solr.interfaces.IKitconceptSolrSettings`](./src/kitconcept/solr/profiles/default/registry/kitconcept.solr.interfaces.IKitconceptSolrSettings.xml) can be customized in the registry via GenericSetup.
 
 ### Update translations
 
 ```bash
 make i18n
 ```
+
 ### Format codebase
 
 ```bash
 make format
 ```
+
 ### Run tests
 
 Testing of this package is done with [`pytest`](https://docs.pytest.org/) and [`tox`](https://tox.wiki/).
@@ -136,7 +234,6 @@ Run only tests that match `TestEndpointEncoding`, but stop on the first error an
 ```bash
 ./bin/tox -e test -- -k TestEndpointEncoding -x --pdb
 ```
-
 
 ## License
 

--- a/news/12.internal
+++ b/news/12.internal
@@ -1,0 +1,1 @@
+Revamp solr configuration @reebalazs

--- a/src/kitconcept/solr/services/solr_utils.py
+++ b/src/kitconcept/solr/services/solr_utils.py
@@ -15,6 +15,22 @@ class SolrConfig:
         search_tabs = self.config.get("searchTabs", [])
         self.filters = [item["filter"] for item in search_tabs]
 
+    @property
+    def labels(self):
+        labels = list(
+            map(lambda item: item.get("label", ""), self.config.get("searchTabs", []))
+        )
+        if len(labels) == 0:
+            raise SolrConfigError(
+                "Error parsing solr config, searchTabs either missing or empty"
+            )
+        invalid_labels = [label for label in labels if not label]
+        if invalid_labels:
+            raise SolrConfigError(
+                "Error parsing solr config, missing label in searchTabs. Labels are mandatory."
+            )
+        return labels
+
     def select_condition(self, group_select: str) -> str:
         filters = self.filters
         base_query = "{!tag=typefilter}"
@@ -31,6 +47,6 @@ class SolrConfig:
         invalid_fields = [item for item in raw_value if "," in item]
         if invalid_fields:
             raise SolrConfigError(
-                "Error parsing json config, fieldList item contains comma (,) which is prohibited"
+                "Error parsing solr config, fieldList item contains comma (,) which is prohibited"
             )
         return ",".join(raw_value)

--- a/tests/services/custom_config/test_endpoint_custom.py
+++ b/tests/services/custom_config/test_endpoint_custom.py
@@ -57,10 +57,15 @@ class TestEndpointCustom:
 class TestEndpointCustomBaseSearch(TestEndpointCustom):
     url = "/@solr?q=chomsky"
 
-    def test_group_counts(self):
+    def test_facet_groups(self):
         # Using default configuration
         assert "response" in self.data
-        assert self.data.get("group_counts") == [3, 1, 1, 2]
+        assert self.data.get("facet_groups") == [
+            ["All", 3],
+            ["Pages", 1],
+            ["News Items", 1],
+            ["Pages and News Items", 2],
+        ]
 
     @pytest.mark.parametrize(
         "path,expected",

--- a/tests/services/default_config/test_endpoint_default.py
+++ b/tests/services/default_config/test_endpoint_default.py
@@ -12,10 +12,16 @@ class TestEndpointDefault:
 class TestEndpointDefaultBaseSearch(TestEndpointDefault):
     url = "/@solr?q=chomsky"
 
-    def test_group_counts(self):
+    def test_facet_groups(self):
         # Using default configuration
         assert "response" in self.data
-        assert self.data.get("group_counts") == [3, 1, 0, 1, 0]
+        assert self.data.get("facet_groups") == [
+            ["All", 3],
+            ["Pages", 1],
+            ["Events", 0],
+            ["Images", 1],
+            ["Files", 0],
+        ]
 
     @pytest.mark.parametrize(
         "path,expected",
@@ -55,10 +61,16 @@ class TestEndpointDefaultGroupSelectAll(TestEndpointDefault):
 class TestEndpointDefaultGroupSelect1(TestEndpointDefault):
     url = "/@solr?q=chomsky&group_select=1"
 
-    def test_group_counts(self):
+    def test_facet_groups(self):
         # Using default configuration
         assert "response" in self.data
-        assert self.data.get("group_counts") == [3, 1, 0, 1, 0]
+        assert self.data.get("facet_groups") == [
+            ["All", 3],
+            ["Pages", 1],
+            ["Events", 0],
+            ["Images", 1],
+            ["Files", 0],
+        ]
 
     @pytest.mark.parametrize(
         "path,expected",

--- a/tests/services/response/test_response.py
+++ b/tests/services/response/test_response.py
@@ -1,0 +1,78 @@
+import pytest
+
+
+solr_config = {
+    "fieldList": [
+        "UID",
+        "Title",
+        "Description",
+        "Type",
+        "effective",
+        "start",
+        "created",
+        "end",
+        "path_string",
+        "phone",
+        "email",
+        "location",
+    ],
+    "searchTabs": [
+        {
+            "label": "All",
+            "filter": "Type(*)",
+        },
+        {
+            "label": "Pages",
+            "filter": "Type:(Page)",
+        },
+        {
+            "label": "News Items",
+            "filter": 'Type:("News Item")',
+        },
+        {
+            "label": "Pages and News Items",
+            "filter": 'Type:(Page OR "News Item")',
+        },
+    ],
+}
+
+
+@pytest.fixture()
+def registry_config() -> dict:
+    """Override registry configuration."""
+    return {
+        "collective.solr.active": 1,
+        "kitconcept.solr.config": solr_config,
+    }
+
+
+class TestResponseCustom:
+    @pytest.fixture(autouse=True)
+    def _init(self, portal_with_content, manager_request):
+        self.portal = portal_with_content
+        response = manager_request.get(self.url)
+        self.data = response.json()
+
+
+class TestResponseKeepFullSolrResponseDefault(TestResponseCustom):
+    url = "/@solr?q=chomsky"
+
+    def test_facet_counts(self):
+        assert "response" in self.data
+        assert "facet_counts" not in self.data
+
+
+class TestResponseKeepFullSolrResponseIsFalse(TestResponseCustom):
+    url = "/@solr?q=chomsky&keep_full_solr_response=false"
+
+    def test_facet_counts(self):
+        assert "response" in self.data
+        assert "facet_counts" not in self.data
+
+
+class TestResponseKeepFullSolrResponseDefaultIsTrue(TestResponseCustom):
+    url = "/@solr?q=chomsky&keep_full_solr_response=true"
+
+    def test_facet_counts(self):
+        assert "response" in self.data
+        assert "facet_counts" in self.data

--- a/tests/utils/conftest.py
+++ b/tests/utils/conftest.py
@@ -1,0 +1,86 @@
+from collections import defaultdict
+from plone import api
+from plone.app.testing import SITE_OWNER_NAME
+from plone.app.testing import SITE_OWNER_PASSWORD
+from plone.restapi.testing import RelativeSession
+from zope.component.hooks import setSite
+
+import pytest
+import transaction
+
+
+@pytest.fixture()
+def app(functional):
+    return functional["app"]
+
+
+@pytest.fixture
+def create_contents():
+    """Helper fixture to create initial content."""
+
+    def func(portal) -> dict:
+        ids = defaultdict(list)
+        return ids
+
+    return func
+
+
+@pytest.fixture()
+def portal(app, registry_config):
+    """Plone portal with additional users, and registry configuration set."""
+    portal = app["plone"]
+    setSite(portal)
+    current_values = {}
+    with api.env.adopt_roles(["Manager", "Member"]):
+        for key, value in registry_config.items():
+            current_values[key] = api.portal.get_registry_record(key)
+            api.portal.set_registry_record(key, value)
+    transaction.commit()
+    yield portal
+    with api.env.adopt_roles(["Manager"]):
+        for key, value in current_values.items():
+            api.portal.set_registry_record(key, value)
+    transaction.commit()
+
+
+@pytest.fixture()
+def portal_with_content(app, portal, create_contents):
+    """Plone portal with initial content."""
+    with api.env.adopt_roles(["Manager"]):
+        content_ids = create_contents(portal)
+    transaction.commit()
+    yield portal
+    with api.env.adopt_roles(["Manager"]):
+        containers = sorted([path for path in content_ids.keys()], reverse=True)
+        for container_path in containers:
+            container = portal.unrestrictedTraverse(container_path)
+            container.manage_delObjects(content_ids[container_path])
+    transaction.commit()
+
+
+@pytest.fixture()
+def request_factory(portal):
+    """Fixture returning a session to call the API."""
+
+    def factory() -> RelativeSession:
+        url = portal.absolute_url()
+        api_session = RelativeSession(url)
+        api_session.headers.update({"Accept": "application/json"})
+        return api_session
+
+    return factory
+
+
+@pytest.fixture()
+def anon_request(request_factory):
+    """Anonymous API requests."""
+    return request_factory()
+
+
+@pytest.fixture()
+def manager_request(request_factory):
+    """Manager API requests."""
+    request = request_factory()
+    request.auth = (SITE_OWNER_NAME, SITE_OWNER_PASSWORD)
+    yield request
+    request.auth = ()

--- a/tests/utils/test_utils.py
+++ b/tests/utils/test_utils.py
@@ -1,0 +1,96 @@
+from kitconcept.solr.services.solr_utils import SolrConfig
+
+import pytest
+
+
+solr_config = {
+    "fieldList": [
+        "UID",
+        "Title",
+        "Description",
+        "Type",
+        "effective",
+        "start",
+        "created",
+        "end",
+        "path_string",
+        "phone",
+        "email",
+        "location",
+    ],
+    "searchTabs": [
+        {
+            "label": "All",
+            "filter": "Type(*)",
+        },
+        {
+            "label": "Pages",
+            "filter": "Type:(Page)",
+        },
+        {
+            "label": "News Items",
+            "filter": 'Type:("News Item")',
+        },
+        {
+            "label": "Pages and News Items",
+            "filter": 'Type:(Page OR "News Item")',
+        },
+    ],
+}
+
+
+@pytest.fixture()
+def registry_config() -> dict:
+    """Override registry configuration."""
+    return {
+        "kitconcept.solr.config": solr_config,
+    }
+
+
+class TestUtils:
+    @pytest.fixture(autouse=True)
+    def _init(self, portal_with_content):
+        self.portal = portal_with_content
+        self.solr_config = SolrConfig()
+
+
+class TestUtilsLabels(TestUtils):
+    def test_labels(self):
+        assert self.solr_config.labels == [
+            "All",
+            "Pages",
+            "News Items",
+            "Pages and News Items",
+        ]
+
+
+class TestUtilsSelectCondition(TestUtils):
+    def test_select_condition(self):
+        assert self.solr_config.select_condition(0) == "{!tag=typefilter}Type(*)"
+        assert self.solr_config.select_condition(1) == "{!tag=typefilter}Type:(Page)"
+        assert (
+            self.solr_config.select_condition(2)
+            == '{!tag=typefilter}Type:("News Item")'
+        )
+        assert (
+            self.solr_config.select_condition(3)
+            == '{!tag=typefilter}Type:(Page OR "News Item")'
+        )
+
+
+class TestUtilsFacetQuery(TestUtils):
+    def test_facet_query(self):
+        assert self.solr_config.facet_query == [
+            "{!ex=typefilter}Type(*)",
+            "{!ex=typefilter}Type:(Page)",
+            '{!ex=typefilter}Type:("News Item")',
+            '{!ex=typefilter}Type:(Page OR "News Item")',
+        ]
+
+
+class TestUtilsFieldList(TestUtils):
+    def test_field_list(self):
+        assert (
+            self.solr_config.field_list
+            == "UID,Title,Description,Type,effective,start,created,end,path_string,phone,email,location"
+        )

--- a/tests/utils/test_utils_emptylabels.py
+++ b/tests/utils/test_utils_emptylabels.py
@@ -1,0 +1,61 @@
+from kitconcept.solr.services.solr_utils import SolrConfig
+from kitconcept.solr.services.solr_utils import SolrConfigError
+
+import pytest
+
+
+solr_config = {
+    "fieldList": [
+        "UID",
+        "Title",
+        "Description",
+        "Type",
+        "effective",
+        "start",
+        "created",
+        "end",
+        "path_string",
+        "phone",
+        "email",
+        "location",
+    ],
+    "searchTabs": [
+        {
+            "label": "All",
+            "filter": "Type(*)",
+        },
+        {
+            # This label is empty
+            "label": "",
+            "filter": "Type:(Page)",
+        },
+        {
+            "label": "News Items",
+            "filter": 'Type:("News Item")',
+        },
+        {
+            "label": "Pages and News Items",
+            "filter": 'Type:(Page OR "News Item")',
+        },
+    ],
+}
+
+
+@pytest.fixture()
+def registry_config() -> dict:
+    """Override registry configuration."""
+    return {
+        "kitconcept.solr.config": solr_config,
+    }
+
+
+class TestUtilsEmptyLabels:
+    @pytest.fixture(autouse=True)
+    def _init(self, portal_with_content):
+        self.portal = portal_with_content
+        self.solr_config = SolrConfig()
+
+    def test_empty_labels(self):
+        with pytest.raises(SolrConfigError) as exc_info:
+            self.solr_config.labels
+        assert exc_info.type is SolrConfigError

--- a/tests/utils/test_utils_emptysearchtabs.py
+++ b/tests/utils/test_utils_emptysearchtabs.py
@@ -1,0 +1,43 @@
+from kitconcept.solr.services.solr_utils import SolrConfig
+from kitconcept.solr.services.solr_utils import SolrConfigError
+
+import pytest
+
+
+solr_config = {
+    "fieldList": [
+        "UID",
+        "Title",
+        "Description",
+        "Type",
+        "effective",
+        "start",
+        "created",
+        "end",
+        "path_string",
+        "phone",
+        "email",
+        "location",
+    ],
+    "searchTabs": [],
+}
+
+
+@pytest.fixture()
+def registry_config() -> dict:
+    """Override registry configuration."""
+    return {
+        "kitconcept.solr.config": solr_config,
+    }
+
+
+class TestUtilsEmptySearchTabs:
+    @pytest.fixture(autouse=True)
+    def _init(self, portal_with_content):
+        self.portal = portal_with_content
+        self.solr_config = SolrConfig()
+
+    def test_empty_search_tabs(self):
+        with pytest.raises(SolrConfigError) as exc_info:
+            self.solr_config.labels
+        assert exc_info.type is SolrConfigError

--- a/tests/utils/test_utils_fieldlwithcomma.py
+++ b/tests/utils/test_utils_fieldlwithcomma.py
@@ -1,0 +1,61 @@
+from kitconcept.solr.services.solr_utils import SolrConfig
+from kitconcept.solr.services.solr_utils import SolrConfigError
+
+import pytest
+
+
+solr_config = {
+    "fieldList": [
+        "UID",
+        "Title",
+        "Description",
+        "Type",
+        # This field has a comma
+        "effective,withcomma",
+        "start",
+        "created",
+        "end",
+        "path_string",
+        "phone",
+        "email",
+        "location",
+    ],
+    "searchTabs": [
+        {
+            "label": "All",
+            "filter": "Type(*)",
+        },
+        {
+            "label": "Pages",
+            "filter": "Type:(Page)",
+        },
+        {
+            "label": "News Items",
+            "filter": 'Type:("News Item")',
+        },
+        {
+            "label": "Pages and News Items",
+            "filter": 'Type:(Page OR "News Item")',
+        },
+    ],
+}
+
+
+@pytest.fixture()
+def registry_config() -> dict:
+    """Override registry configuration."""
+    return {
+        "kitconcept.solr.config": solr_config,
+    }
+
+
+class TestUtilsFieldListWithComma:
+    @pytest.fixture(autouse=True)
+    def _init(self, portal_with_content):
+        self.portal = portal_with_content
+        self.solr_config = SolrConfig()
+
+    def test_field_list_with_comma(self):
+        with pytest.raises(SolrConfigError) as exc_info:
+            self.solr_config.field_list
+        assert exc_info.type is SolrConfigError

--- a/tests/utils/test_utils_missinglabels.py
+++ b/tests/utils/test_utils_missinglabels.py
@@ -1,0 +1,60 @@
+from kitconcept.solr.services.solr_utils import SolrConfig
+from kitconcept.solr.services.solr_utils import SolrConfigError
+
+import pytest
+
+
+solr_config = {
+    "fieldList": [
+        "UID",
+        "Title",
+        "Description",
+        "Type",
+        "effective",
+        "start",
+        "created",
+        "end",
+        "path_string",
+        "phone",
+        "email",
+        "location",
+    ],
+    "searchTabs": [
+        {
+            "label": "All",
+            "filter": "Type(*)",
+        },
+        {
+            # This label is missing
+            "filter": "Type:(Page)",
+        },
+        {
+            "label": "News Items",
+            "filter": 'Type:("News Item")',
+        },
+        {
+            "label": "Pages and News Items",
+            "filter": 'Type:(Page OR "News Item")',
+        },
+    ],
+}
+
+
+@pytest.fixture()
+def registry_config() -> dict:
+    """Override registry configuration."""
+    return {
+        "kitconcept.solr.config": solr_config,
+    }
+
+
+class TestUtilsMissingLabels:
+    @pytest.fixture(autouse=True)
+    def _init(self, portal_with_content):
+        self.portal = portal_with_content
+        self.solr_config = SolrConfig()
+
+    def test_missing_labels(self):
+        with pytest.raises(SolrConfigError) as exc_info:
+            self.solr_config.labels
+        assert exc_info.type is SolrConfigError


### PR DESCRIPTION
- restructure service response to return facet labels with the counts
  as well
- add keep_full_solr_response option, prune payload by default
- add documentation

In addition:

- fix makefile, `make solr-start` etc. to work