### PR TITLE
Increase version of collective.solr

### DIFF
--- a/news/14.bugfix
+++ b/news/14.bugfix
@@ -1,0 +1,1 @@
+Increase version of collective.solr @reebalazs

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(
         "plone.restapi>=8.40.0",
         "plone.api",
         "setuptools",
-        "collective.solr",
+        "collective.solr>=9.0.1",
     ],
     extras_require={
         "test": [


### PR DESCRIPTION
Needed for `image_scales` to be serialized correctly.