### PR TITLE
Fix dense vector field schema and guard CI against solr-only regressions

### DIFF
--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -90,6 +90,7 @@ jobs:
             backend:
               - 'backend/**'
               - '.github/workflows/backend*'
+              - 'solr/**'
             docs:
               - '.readthedocs.yaml'
               - 'docs/**'

--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -86,6 +86,7 @@ jobs:
               - 'docker-compose*'
               - 'backend/**'
               - 'frontend/**'
+              - 'solr/**'
             backend:
               - 'backend/**'
               - '.github/workflows/backend*'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,6 +8,7 @@ on:
       - "backend/**"
       - "docs/**"
       - "frontend/**"
+      - "solr/**"
   workflow_dispatch:
 
 env:

--- a/.github/workflows/solr.yml
+++ b/.github/workflows/solr.yml
@@ -42,6 +42,34 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 
+      - name: Build amd64 image for smoke test
+        uses: docker/build-push-action@v3
+        with:
+          platforms: linux/amd64
+          context: solr
+          file: solr/Dockerfile
+          load: true
+          tags: kitconcept-solr-smoke:local
+
+      - name: Smoke test - plone core loads on startup
+        run: |
+          docker run -d --name solr-smoke -p 8983:8983 kitconcept-solr-smoke:local
+          # If the schema is broken the core fails to load, but Jetty still
+          # starts. /solr/plone/admin/ping returns 404 in that case.
+          for i in $(seq 1 60); do
+            if curl -fsS "http://localhost:8983/solr/plone/admin/ping?wt=json" 2>/dev/null | grep -q '"status":"OK"'; then
+              echo "Solr plone core loaded and healthy"
+              docker rm -f solr-smoke >/dev/null
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "Solr plone core failed to come up healthy after 120s"
+          echo "--- container logs ---"
+          docker logs solr-smoke
+          docker rm -f solr-smoke >/dev/null
+          exit 1
+
       - name: Login to Container Registry
         uses: docker/login-action@v2
         with:

--- a/news/+ciSolrSmokeAndAcceptance.internal
+++ b/news/+ciSolrSmokeAndAcceptance.internal
@@ -1,0 +1,1 @@
+Run acceptance tests on `solr/**` changes and smoke-test the built Solr image (boot it and ping the `plone` core) before pushing it. @reebalazs

--- a/news/+ciSolrSmokeAndAcceptance.internal
+++ b/news/+ciSolrSmokeAndAcceptance.internal
@@ -1,1 +1,1 @@
-Run acceptance tests on `solr/**` changes and smoke-test the built Solr image (boot it and ping the `plone` core) before pushing it. @reebalazs
+Run acceptance and backend tests on `solr/**` changes, and smoke-test the built Solr image (boot it and ping the `plone` core) before pushing it. @reebalazs

--- a/news/+fixDenseVectorFieldAttribute.bugfix
+++ b/news/+fixDenseVectorFieldAttribute.bugfix
@@ -1,0 +1,1 @@
+Fix `knn_vector_768` field type so the Solr core can load: use `hnswBeamWidth` instead of the unrecognized `hnswEfConstruction` attribute on `solr.DenseVectorField`. @reebalazs

--- a/solr/etc/conf/schema.xml
+++ b/solr/etc/conf/schema.xml
@@ -229,7 +229,7 @@
                class="solr.DenseVectorField"
                vectorDimension="768"
                similarityFunction="dot_product"
-               hnswEfConstruction="200"/>
+               hnswBeamWidth="200"/>
 
   </types>
 


### PR DESCRIPTION
## Summary

- Fix the `knn_vector_768` field type in [solr/etc/conf/schema.xml](solr/etc/conf/schema.xml): replace the unrecognized `hnswEfConstruction` attribute with `hnswBeamWidth`. With the broken attribute on `main` the Solr `plone` core fails to load on startup (`org.apache.solr.common.SolrException: Unable to create core [plone]`), so the indexer is non-functional on the current `latest` image. Verified the valid attribute names by inspecting `DenseVectorField.class` inside `ghcr.io/kitconcept/solr:latest`.
- Run the acceptance suite on `solr/**` changes. `main.yml`'s push trigger and `config.yml`'s `acceptance` path-filter both omitted `solr/**`, so a solr-only PR (like the one that introduced the broken attribute) silently bypassed every test that actually starts Solr. The `solr-acceptance` service is built from the working tree (`docker-compose-ci.yml`), so this immediately tests the latest schema with no extra plumbing.
- Add a smoke-test step in `solr.yml`. The image-build workflow previously did `docker build` + `docker push` only — a schema that fails core-load still produces a buildable image. The new step boots the freshly built amd64 image and polls `/solr/plone/admin/ping`, which returns 404 when the core failed to load. Multi-arch push only runs if the smoke test passes, so we stop publishing broken `:latest` images.

## Test plan

- [x] `Solr image creation` workflow runs — including the new smoke-test step — and the multi-arch push only happens after it passes.
- [x] `kitconcept Solr CI` (main.yml) now triggers on this PR (previously a solr-only change wouldn't have triggered it at all).
- [x] All five acceptance Cypress jobs (Solr / Search Blocks / Search Document / Search File / Search UI) run and pass against the locally-built `solr-acceptance` container.