### PR TITLE
Hide empty search tabs container on empty search term

### DIFF
--- a/frontend/packages/volto-solr/news/+hideEmptySearchTabs.bugfix
+++ b/frontend/packages/volto-solr/news/+hideEmptySearchTabs.bugfix
@@ -1,0 +1,1 @@
+Hide the empty search tabs container on an empty search term, so it no longer renders as a stray grey rectangle. @reebalazs

--- a/frontend/packages/volto-solr/src/theme/solrsearch.less
+++ b/frontend/packages/volto-solr/src/theme/solrsearch.less
@@ -219,6 +219,13 @@
     display: inline-block;
   }
 
+  // Hide the empty search tabs container (e.g. on an empty search term, when
+  // there are no facet groups). Semantic UI's `.ui.menu` enforces a `min-height`,
+  // so an empty `.searchTabs` would otherwise render as a stray grey rectangle.
+  .searchTabs.ui.tabular.menu:empty {
+    display: none;
+  }
+
   .searchTabs.ui.tabular.menu {
     display: block;
     border-bottom: none;


### PR DESCRIPTION
## What

On the search results page, entering an empty search term left a stray grey rectangle where the search tabs (`.searchTabs`) normally appear.

## Cause

With an empty search term there are no facet groups, so `SearchTabs` renders an empty container. Semantic UI's `.ui.menu` enforces a `min-height`, so the empty element still paints as a grey box.

## Fix

Collapse the container in its empty state with `.searchTabs.ui.tabular.menu:empty { display: none; }` in `solrsearch.less`.