### PR TITLE
Tag the Solr image with the release number

### DIFF
--- a/.github/workflows/solr.yml
+++ b/.github/workflows/solr.yml
@@ -33,6 +33,7 @@ jobs:
             latest=false
           tags: |
             type=ref,event=branch
+            type=ref,event=tag
             type=sha
             type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
 

--- a/README.md
+++ b/README.md
@@ -405,6 +405,20 @@ Create a file `profiles/default/registry/kitconcept.solr.interfaces.IKitconceptS
 
 This repository provides a Solr Docker image preconfigured for Plone at `ghcr.io/kitconcept/solr`.
 
+The image is published with the following tags:
+
+| Tag | Description |
+| --- | --- |
+| `latest` | Latest build from the `main` branch. |
+| `2.0.0a14` (release number) | Published for each release. Pin this to the same release number as the `kitconcept.solr` backend and `@kitconcept/volto-solr` frontend packages so that compatible versions are used together. |
+| `sha-db2c24c` (commit SHA) | Build of a specific commit. |
+
+For production deployments, pin the release-number tag matching the backend and frontend package versions, e.g.:
+
+```yaml
+    image: ghcr.io/kitconcept/solr:2.0.0a14
+```
+
 #### Docker Compose Example
 
 ```yaml

--- a/news/76.internal
+++ b/news/76.internal
@@ -1,0 +1,1 @@
+Tag the published Solr image (`ghcr.io/kitconcept/solr`) with the release number in addition to the commit SHA, so consumers can pin the same release number for the backend, frontend and Solr image. @reebalazs


### PR DESCRIPTION
## What

Adds `type=ref,event=tag` to the `docker/metadata-action` tag list in the Solr image workflow, so that pushing a release tag (e.g. `2.0.0a15`) also publishes `ghcr.io/kitconcept/solr:2.0.0a15`.

## Why

The backend and frontend packages are tagged with the release number, but the Solr image only got `sha-*` tags, so consumers had to look up the commit SHA to pin a release. With this change, a consumer can use the same release number for the frontend package, the backend package, and the Solr image, ensuring compatible versions are selected together.

## Notes

- No trigger change is needed: tag pushes already trigger this workflow (GitHub does not evaluate `paths:` filters for tag pushes — see the existing runs for `2.0.0a14`, `2.0.0a13`, etc.). Those runs just didn't produce a version-named image tag until now.
- `type=ref,event=tag` is used instead of `type=pep440`/`type=semver` because those fail the workflow on tags that don't parse as versions, and this repo deliberately pushes non-version tags (`fhnw-features-*`) to trigger image builds.
- The `sha-*` tags and the `latest` (main branch only) semantics are unchanged.
- README documents the published tags and recommends pinning the release number.
- The current release will be backfilled manually after merge: `docker buildx imagetools create -t ghcr.io/kitconcept/solr:2.0.0a14 ghcr.io/kitconcept/solr:sha-a4152ea`