### PR TITLE
Stop tika-acceptance container when stopping the acceptance backend

### DIFF
--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -84,6 +84,7 @@ jobs:
               - '.github/workflows/frontend*'
               - '.github/workflows/config*'
               - 'docker-compose*'
+              - 'Makefile'
               - 'backend/**'
               - 'frontend/**'
               - 'solr/**'

--- a/Makefile
+++ b/Makefile
@@ -237,7 +237,10 @@ solr-activate-and-reindex-clear: ## Activate solr and reindex content with clear
 .PHONY: acceptance-backend-dev-start
 acceptance-backend-dev-start:
 	@echo "Start acceptance backend and solr"
-	@docker compose -f $(STACK_FILE_DEV) up backend-acceptance solr-acceptance --build
+	@# tika-acceptance is named explicitly (not just pulled in as a solr-acceptance
+	@# dependency) so that `docker compose up` also stops it on Ctrl-C. Otherwise
+	@# the tika container is left running after the stack is stopped.
+	@docker compose -f $(STACK_FILE_DEV) up backend-acceptance solr-acceptance tika-acceptance --build
 
 .PHONY: acceptance-frontend-dev-start
 acceptance-frontend-dev-start:

--- a/news/+acceptance-tika-orphan.internal
+++ b/news/+acceptance-tika-orphan.internal
@@ -1,0 +1,1 @@
+Stop the `tika-acceptance` container when the acceptance backend is stopped. `make acceptance-backend-dev-start` now names it explicitly in `docker compose up` so Ctrl-C tears it down instead of leaving it running. @reebalazs


### PR DESCRIPTION
## Summary

`make acceptance-backend-dev-start` left the `tika-acceptance` container running after the acceptance stack was stopped.

The target ran:

```
docker compose -f docker-compose-dev.yml up backend-acceptance solr-acceptance --build
```

`tika-acceptance` only came up as a `depends_on` dependency of `solr-acceptance`. On Ctrl-C, `docker compose up` stops the services it was explicitly given (backend-acceptance, solr-acceptance) but leaves such dependencies running — so tika was orphaned.

## Fix

Name `tika-acceptance` explicitly in the `up` command so compose attaches to it and tears it down together with the rest on Ctrl-C.

## Verification

Reproduced deterministically (even a single Ctrl-C): with only `solr-acceptance` named, `solr-acceptance` stops but `tika-acceptance` stays `Up`. With `tika-acceptance` named as well, a single Ctrl-C stops both.