### PR TITLE
Add specification and implementation plan for the AI search (RAG) feature

### DIFF
--- a/IMPLEMENTATION-79.md
+++ b/IMPLEMENTATION-79.md
@@ -1,0 +1,178 @@
+# AI Search (RAG) — Implementation Plan
+
+Ticket: [#79](https://github.com/kitconcept/kitconcept.solr/issues/79)
+Companion document: [SPECIFICATION-79.md](./SPECIFICATION-79.md)
+
+The plan is organized in phases so that each phase ends in something
+demonstrable and measurable. Phases 1–4 constitute the MVP; Phase 5 is the
+quality pass that decides the remaining tuning questions with data.
+
+Integration points reference the current codebase (2.0.0 alpha series).
+
+## Phase 0 — Planning and decisions (this ticket)
+
+- [x] Research: Solr vector/hybrid capabilities, chunking practice, RAG
+      evaluation standards, demo corpus options (results folded into the
+      specification).
+- [x] Specification draft (SPECIFICATION-79.md).
+- [ ] Review the specification with the team; close open questions **1**
+      (chunk storage), **3** (embedding model / German) and **7** (demo
+      corpus) — these block Phases 1–2.
+- [ ] Confirm access to the kitconcept Ollama server (URL, credentials,
+      available models) and that `nomic-embed-text`(-v2-moe) is served.
+
+## Phase 1 — Retrieval foundation (backend)
+
+Goal: a question typed into a REST call returns permission-trimmed, ranked
+documents via vector search. No LLM answer yet. This is the riskiest layer,
+so it goes first and gets measured first.
+
+- [ ] **1.1 Ollama client module** (`backend/src/kitconcept/solr/llm/`):
+      thin HTTP client for `POST /api/embed` (batched, `num_ctx: 8192`,
+      task prefixes `search_document:` / `search_query:`) and
+      `POST /api/chat` (Phase 3). Explicit timeouts; typed errors;
+      no third-party LLM framework dependency.
+- [ ] **1.2 Configuration plumbing**: registry records on
+      `IKitconceptSolrSettings` (`backend/src/kitconcept/solr/interfaces.py`
+      + `profiles/default/registry/`): `rag_enabled`, model names, `topK`,
+      chunking parameters. Env vars for endpoint URL + token, wired through
+      `docker-compose.yml` like `COLLECTIVE_SOLR_HOST`.
+- [ ] **1.3 Chunking**: split extracted block text (reusing the traversal in
+      `backend/src/kitconcept/solr/indexers/text.py`) into ~500-token
+      structure-aware chunks with 10–15% overlap.
+- [ ] **1.4 Index-time embedding**: hook after document assembly for
+      `collective.solr` so each indexed object also writes its chunk
+      documents (sibling docs with `parent_uid`, denormalized `Title`,
+      `path`, `allowedRolesAndUsers`, `Language`) with `content_vector`
+      populated. Schema updates in `solr/etc/conf/schema.xml` (chunk fields);
+      delete/unindex removes chunks; embedding-endpoint failure logs and
+      skips vectors without failing the save. Record model name in the
+      index for reindex detection.
+- [ ] **1.5 Full-reindex support**: make `solr-activate-and-reindex`
+      populate vectors using batched `/api/embed` calls.
+- [ ] **1.6 Retrieval service** `@rag-search` (retrieval part only, staged
+      behind the toggle): embed query (`search_query:` prefix), run
+      `{!knn f=content_vector topK=K}` with the same `fq` security/path/
+      language filters as `SolrSearch` (`services/solr.py` —
+      `security_filter()` composes as knn pre-filter), collapse chunk hits
+      to parent documents, return ranked sources.
+- [ ] **1.7 Tests**: unit tests for chunker and client (mocked HTTP);
+      integration test against the docker-compose stack with a fake/pinned
+      embedding server (deterministic vectors) so CI needs no GPU/model.
+- [ ] **1.8 Dev stack**: add an `ollama` service (or a lightweight mock) to
+      `docker-compose-dev.yml`; Makefile targets; document local setup.
+
+Demo at end of phase: `curl` the endpoint, see sensible documents ranked for
+a natural-language question on a local site.
+
+## Phase 2 — Demo corpus, golden questions, retrieval evaluation
+
+Goal: an objective measure of retrieval quality; also the demo site asset.
+Can start in parallel with Phase 1 (only its evaluation step depends on 1).
+
+- [ ] **2.1 Demo corpus**: generate the synthetic fictional-organization
+      corpus (~50–150 docs, LLM-generated with agents, human-reviewed for
+      internal consistency; language per open question 7). Import into a
+      local site; export via `plone.exportimport` and ship as demo-site data
+      in the product (per the kickoff: a kitconcept.solr example site,
+      useful beyond this feature).
+- [ ] **2.2 Golden question set**: 30–50 `question / expected sources /
+      reference answer` triples in-repo (JSON/YAML). Bootstrapped with a
+      generator + personas, manually culled; include CRAG-style variety and
+      explicitly unanswerable questions.
+- [ ] **2.3 Retrieval evaluation script** (`scripts/` or `backend/tools/`):
+      run the golden set against `@rag-search` retrieval, report
+      Recall@5/10, MRR, nDCG@10 (`ranx`). Makefile target; optional CI job.
+- [ ] **2.4 Baseline run**: record baseline numbers; sanity-check against
+      plain BM25 `@solr` results for the same questions (this comparison
+      feeds open question 2, pure-vector vs hybrid).
+
+Demo at end of phase: an evaluation report ("Recall@10 = X on N questions")
+on a reproducible demo site.
+
+## Phase 3 — Answer generation (backend)
+
+Goal: `@rag-search` returns `{answer, sources}`.
+
+- [ ] **3.1 Prompt template**: fixed instruction template (answer only from
+      the provided context; match the question's language; say "no answer
+      found in the documentation" when applicable; refer to sources).
+      Stored server-side, overridable via registry.
+- [ ] **3.2 Generation call**: send question + matched chunks (+ parent
+      title/URL) to the general LLM; compose the response object; structured
+      errors for timeout/unavailable/not-configured.
+- [ ] **3.3 Model bake-off**: try the candidate models on the kitconcept
+      Ollama server against the golden set; pick the MVP default (open
+      question 5).
+- [ ] **3.4 Tests**: service tests with a mocked generation endpoint
+      (deterministic canned answers); error-path tests.
+
+Demo at end of phase: full RAG loop over REST on the demo site.
+
+## Phase 4 — Frontend (Volto modal UI)
+
+Goal: the user-facing MVP in `@kitconcept/volto-solr`.
+
+- [ ] **4.1 Short UX spec**: states (idle/loading/answer/error/disabled),
+      keyboard behavior (⌘K open, Esc close), AI-disclaimer copy, relation
+      to the existing search bar (open question 8). Wireframe level; review
+      with the team before building.
+- [ ] **4.2 Redux plumbing**: `actions/ragsearch/` + `reducers/ragsearch/`
+      calling `@rag-search` (pattern: existing `actions/solrsearch/`).
+- [ ] **4.3 Modal component**: command-palette modal
+      (`components/theme/`…): input, loading state, answer panel with
+      disclaimer, source list reusing the existing result-item rendering
+      from `SolrSearch`; graceful fallback link to classic search on error;
+      hidden entirely when the backend reports not-configured.
+- [ ] **4.4 Tests**: Jest component tests; one Cypress acceptance flow
+      against a mocked backend answer.
+- [ ] **4.5 i18n** for all new strings (existing i18n setup).
+
+Demo at end of phase: ⌘K on the demo site → ask → answer + sources. **This
+is the MVP.**
+
+## Phase 5 — Quality pass and evaluation tier 2
+
+Goal: decide the data-driven open questions; make quality trustworthy.
+
+- [ ] **5.1 Answer evaluation (RAGAS)**: faithfulness + answer relevancy on
+      the golden set, judge LLM on the same Ollama server; one-time human
+      calibration of the judge on a labeled sample.
+- [ ] **5.2 Hybrid retrieval, if the numbers demand it**: client-side RRF
+      (BM25 + knn, k=60) inside `@rag-search`; re-run the Phase 2 report to
+      confirm the gain. Designed to be swapped for Solr's native RRF
+      combiner when 9.11/10.1 ships.
+- [ ] **5.3 Tuning knobs pass**: `topK`, chunk size/overlap, prompt wording
+      — one iteration guided by the metrics, not more (MVP discipline).
+- [ ] **5.4 Acceptance thresholds**: fix the release criteria (proposal in
+      spec §7) with the measured baseline; wire the retrieval evaluation
+      into CI as a regression gate.
+
+## Phase 6 — Post-MVP roadmap (tracked, not scheduled)
+
+- Community LLM-connector add-on integration (requires upstream support for
+  the kitconcept Ollama server) → any-provider support.
+- Control-panel UI for kitconcept.solr configuration incl. AI credentials.
+- Multi-turn conversation; streaming answers; query rewriting; re-ranking;
+  attachments in the modal; model benchmarking across providers.
+- Multilingual optimization (per-language analyzers already exist for
+  keyword search; embedding side per open question 3).
+
+## Risks and mitigations
+
+| Risk | Impact | Mitigation |
+| --- | --- | --- |
+| Pure-vector retrieval quality insufficient on real corpora | wrong sources → wrong answers | Phase 2 measures it early; hybrid RRF is a bounded, planned fallback (5.2) |
+| Ollama server latency/availability | slow saves, hanging searches | strict timeouts everywhere; indexing never fails on embedding errors; frontend error state falls back to classic search |
+| Long-document embedding truncation (`num_ctx` default 2048) | silently bad vectors | chunking keeps inputs ~500 tokens; client always sets `num_ctx`; test asserts prefix+ctx behavior |
+| Embedding model change invalidates index | broken search after model swap | model name recorded at index time; mismatch triggers/reports reindex need |
+| LLM hallucinates sources or answers beyond context | trust damage | prompt constraints; unanswerable questions in golden set; faithfulness metric in 5.1; UI disclaimer |
+| CI cannot run models | untestable feature | all CI tests run against mocked/deterministic endpoints; model-dependent evaluation is a separate opt-in job |
+| Editing latency from synchronous embedding | editor complaints | short timeout + skip-on-failure; batched full reindex; async queue is the documented plan B |
+
+## Suggested working order (tight MVP path)
+
+Decisions 1/3/7 → 1.1–1.2 → 1.3–1.4 → 1.6 → 2.1–2.4 (overlapping) → 3.1–3.2
+→ 4.1–4.3 → 5.1/5.4, with 1.7/3.4/4.4 tests accompanying their phases. Each
+phase lands as one or more reviewed PRs referencing #79; towncrier news
+fragments per PR as usual.

--- a/IMPLEMENTATION-79.md
+++ b/IMPLEMENTATION-79.md
@@ -2,177 +2,164 @@
 
 Ticket: [#79](https://github.com/kitconcept/kitconcept.solr/issues/79)
 Companion document: [SPECIFICATION-79.md](./SPECIFICATION-79.md)
+Status: **approved plan** (team review 2026-07-09). Work is tracked in the
+internal tracker (epic holds the itemized plan; step numbers below map to
+individual tracker tickets). Work starts **after the 2.0 release**, which
+proceeds in parallel.
 
-The plan is organized in phases so that each phase ends in something
-demonstrable and measurable. Phases 1–4 constitute the MVP; Phase 5 is the
-quality pass that decides the remaining tuning questions with data.
+The MVP path is **7.5 dev days** across three steps, followed by post-MVP
+follow-ups. A **checkpoint after 5 dev days** re-evaluates the estimate and
+updates the schedule if necessary.
 
-Integration points reference the current codebase (2.0.0 alpha series).
-
-## Phase 0 — Planning and decisions (this ticket)
+## Step 0 — Planning (done)
 
 - [x] Research: Solr vector/hybrid capabilities, chunking practice, RAG
-      evaluation standards, demo corpus options (results folded into the
-      specification).
-- [x] Specification draft (SPECIFICATION-79.md).
-- [ ] Review the specification with the team; close open questions **1**
-      (chunk storage), **3** (embedding model / German) and **7** (demo
-      corpus) — these block Phases 1–2.
-- [ ] Confirm access to the kitconcept Ollama server (URL, credentials,
-      available models) and that `nomic-embed-text`(-v2-moe) is served.
+      evaluation standards, demo corpus options.
+- [x] Specification, team review, decisions (recorded in
+      SPECIFICATION-79.md §8).
+- [ ] Kick-off prerequisites:
+      - access to the kitconcept LLM server (action item);
+      - clarify the two kinds of chunking (input from Victor) — pick the MVP
+        kind, keep the design compatible with the second;
+      - 2.0 released, or a feature branch policy agreed.
 
-## Phase 1 — Retrieval foundation (backend)
+## Step 1 — Foundations + Indexing (4.5d)
 
-Goal: a question typed into a REST call returns permission-trimmed, ranked
-documents via vector search. No LLM answer yet. This is the riskiest layer,
-so it goes first and gets measured first.
+Goal: content gets chunked, embedded and indexed; the vector infrastructure
+is live. This is the riskiest layer, so it goes first.
 
-- [ ] **1.1 Ollama client module** (`backend/src/kitconcept/solr/llm/`):
-      thin HTTP client for `POST /api/embed` (batched, `num_ctx: 8192`,
-      task prefixes `search_document:` / `search_query:`) and
-      `POST /api/chat` (Phase 3). Explicit timeouts; typed errors;
-      no third-party LLM framework dependency.
-- [ ] **1.2 Configuration plumbing**: registry records on
-      `IKitconceptSolrSettings` (`backend/src/kitconcept/solr/interfaces.py`
-      + `profiles/default/registry/`): `rag_enabled`, model names, `topK`,
-      chunking parameters. Env vars for endpoint URL + token, wired through
-      `docker-compose.yml` like `COLLECTIVE_SOLR_HOST`.
-- [ ] **1.3 Chunking**: split extracted block text (reusing the traversal in
-      `backend/src/kitconcept/solr/indexers/text.py`) into ~500-token
-      structure-aware chunks with 10–15% overlap.
-- [ ] **1.4 Index-time embedding**: hook after document assembly for
+**Foundations (1.5d):**
+
+- [ ] **1.1 LLM client module** (`backend/src/kitconcept/solr/llm/`):
+      thin HTTP client for `POST /api/embed` (batched, `num_ctx` set,
+      task prefixes `search_document:` / `search_query:`, truncation
+      detection) and `POST /api/chat` (used in Step 3). Explicit timeouts;
+      typed errors; no third-party LLM framework dependency.
+- [ ] **1.2 Minimal configuration**: the "AI search" toggle as a registry
+      record on `IKitconceptSolrSettings`
+      (`backend/src/kitconcept/solr/interfaces.py` +
+      `profiles/default/registry/`); endpoint URL + token as env vars wired
+      through `docker-compose.yml` (pattern: `COLLECTIVE_SOLR_HOST`). Model
+      names, topK, chunk parameters, prompt template: code defaults.
+- [ ] **1.3 Schema additions** for chunk sibling documents in
+      `solr/etc/conf/schema.xml` (chunk fields: `parent_uid`, denormalized
+      `Title`, `path`, `allowedRolesAndUsers`, `Language`;
+      `content_vector` populated on chunks).
+
+**Indexing (3d):**
+
+- [ ] **1.4 Chunking**: split extracted block text (reusing the traversal in
+      `backend/src/kitconcept/solr/indexers/text.py`) into ~400-token
+      structure-aware chunks with 10–15% overlap, merging tiny fragments.
+      One kind of chunking (per the kick-off clarification); design kept
+      compatible with the second kind.
+- [ ] **1.5 Index-time embedding**: hook after document assembly for
       `collective.solr` so each indexed object also writes its chunk
-      documents (sibling docs with `parent_uid`, denormalized `Title`,
-      `path`, `allowedRolesAndUsers`, `Language`) with `content_vector`
-      populated. Schema updates in `solr/etc/conf/schema.xml` (chunk fields);
-      delete/unindex removes chunks; embedding-endpoint failure logs and
-      skips vectors without failing the save. Record model name in the
-      index for reindex detection.
-- [ ] **1.5 Full-reindex support**: make `solr-activate-and-reindex`
-      populate vectors using batched `/api/embed` calls.
-- [ ] **1.6 Retrieval service** `@rag-search` (retrieval part only, staged
-      behind the toggle): embed query (`search_query:` prefix), run
+      documents with vectors — synchronous, short timeout,
+      **skip-on-failure** (a save must never fail on embedding errors).
+      Delete/unindex removes chunks. Record the embedding model name for
+      reindex detection.
+- [ ] **1.6 Full-reindex support**: `solr-activate-and-reindex` populates
+      vectors using batched `/api/embed` calls.
+- [ ] Minimal inline test coverage with the PRs (repo CI standards); the
+      full test pass is post-MVP (Step P1).
+
+Demo at end of step: indexed site content visible in Solr with chunk
+documents and populated vectors.
+
+## Step 2 — Test corpus (0.5d)
+
+Goal: content and questions to validate Step 3 against. Lands before or
+together with Step 3.
+
+- [ ] **2.1 Corpus**: translated German template demo content (English),
+      imported into the kitconcept.intranet demo site.
+- [ ] **2.2 Questions**: ~20 hand-written questions with expected source
+      documents, stored alongside the corpus; includes questions whose
+      answer is *not* in the corpus (the system should decline).
+
+Post-MVP: the same export/import dump also drives this repository's CI
+tests (see Step P2 overflow list).
+
+## Step 3 — Query pipeline: retrieval endpoint + answer generation (2.5d)
+
+Goal: `@rag-search` returns `{answer, sources}` end to end.
+
+**Retrieval endpoint (1d):**
+
+- [ ] **3.1** New restapi service `@rag-search`
+      (`backend/src/kitconcept/solr/services/`, staged behind the toggle):
+      embed query (`search_query:` prefix), run
       `{!knn f=content_vector topK=K}` with the same `fq` security/path/
       language filters as `SolrSearch` (`services/solr.py` —
       `security_filter()` composes as knn pre-filter), collapse chunk hits
       to parent documents, return ranked sources.
-- [ ] **1.7 Tests**: unit tests for chunker and client (mocked HTTP);
-      integration test against the docker-compose stack with a fake/pinned
-      embedding server (deterministic vectors) so CI needs no GPU/model.
-- [ ] **1.8 Dev stack**: add an `ollama` service (or a lightweight mock) to
-      `docker-compose-dev.yml`; Makefile targets; document local setup.
 
-Demo at end of phase: `curl` the endpoint, see sensible documents ranked for
-a natural-language question on a local site.
+**Answer generation (1.5d):**
 
-## Phase 2 — Demo corpus, golden questions, retrieval evaluation
+- [ ] **3.2 Prompt template**: fixed instruction template (answer only from
+      the provided context; answer in the question's language; decline
+      explicitly when no answer is found; refer to sources). Code default;
+      registry override is post-MVP.
+- [ ] **3.3 Generation call**: send question + matched chunks (+ parent
+      title/URL) to `qwen3:14b`; compose the `{answer, sources}` response;
+      structured errors for timeout/unavailable/not-configured.
+- [ ] Validate against the Step 2 questions (smoke level: right documents
+      found, declines when it should).
 
-Goal: an objective measure of retrieval quality; also the demo site asset.
-Can start in parallel with Phase 1 (only its evaluation step depends on 1).
+Demo at end of step: full RAG loop over REST on the demo corpus. **This is
+the MVP backend.** The user-facing MVP completes when the search UI from the
+kitconcept.intranet modal project integrates this endpoint (outside this
+repository's estimates).
 
-- [ ] **2.1 Demo corpus**: generate the synthetic fictional-organization
-      corpus (~50–150 docs, LLM-generated with agents, human-reviewed for
-      internal consistency; language per open question 7). Import into a
-      local site; export via `plone.exportimport` and ship as demo-site data
-      in the product (per the kickoff: a kitconcept.solr example site,
-      useful beyond this feature).
-- [ ] **2.2 Golden question set**: 30–50 `question / expected sources /
-      reference answer` triples in-repo (JSON/YAML). Bootstrapped with a
-      generator + personas, manually culled; include CRAG-style variety and
-      explicitly unanswerable questions.
-- [ ] **2.3 Retrieval evaluation script** (`scripts/` or `backend/tools/`):
-      run the golden set against `@rag-search` retrieval, report
-      Recall@5/10, MRR, nDCG@10 (`ranx`). Makefile target; optional CI job.
-- [ ] **2.4 Baseline run**: record baseline numbers; sanity-check against
-      plain BM25 `@solr` results for the same questions (this comparison
-      feeds open question 2, pure-vector vs hybrid).
+## Post-MVP follow-ups
 
-Demo at end of phase: an evaluation report ("Recall@10 = X on N questions")
-on a reproducible demo site.
+**Step P1 — Hybrid RRF + tests (2d), first follow-up:**
 
-## Phase 3 — Answer generation (backend)
+- [ ] **P1.1 Hybrid retrieval (1d)**: BM25 (reusing the existing
+      `SolrSearch` query building) + knn as two Solr requests, client-side
+      Reciprocal Rank Fusion (k=60) in `@rag-search`; designed to be swapped
+      for Solr's native RRF combiner when 9.11/10.1 ships. Hybrid was
+      originally MVP scope (empirical signal that pure vector is not enough
+      on intranet content); the pure-knn MVP results should confirm the
+      deferral was acceptable — if not, this item moves up.
+- [ ] **P1.2 Test pass (1d)**: unit tests (chunker, LLM client mocked) + one
+      integration test against the docker-compose stack with deterministic
+      mock endpoints (CI needs no GPU/model).
 
-Goal: `@rag-search` returns `{answer, sources}`.
+**Step P2 — Overflow tasks** (first candidates after that, or if time
+remains):
 
-- [ ] **3.1 Prompt template**: fixed instruction template (answer only from
-      the provided context; match the question's language; say "no answer
-      found in the documentation" when applicable; refer to sources).
-      Stored server-side, overridable via registry.
-- [ ] **3.2 Generation call**: send question + matched chunks (+ parent
-      title/URL) to the general LLM; compose the response object; structured
-      errors for timeout/unavailable/not-configured.
-- [ ] **3.3 Model bake-off**: try the candidate models on the kitconcept
-      Ollama server against the golden set; pick the MVP default (open
-      question 5).
-- [ ] **3.4 Tests**: service tests with a mocked generation endpoint
-      (deterministic canned answers); error-path tests.
+| Work item | Est. |
+| --- | --- |
+| Adapt chunking to the second kind | 1d |
+| Shared export/import dump: same corpus drives the kitconcept.intranet demo site and this repository's CI tests | 0.5d |
+| Generation model comparison (`qwen3:14b` vs `qwen3.5:9b-q8_0` vs others) on the test questions | 0.5d |
+| Full configuration surface: registry records for model names, topK, chunk size, prompt override | 0.5d |
+| Acceptance test flow + full CI wiring (after the search-UI integration, so acceptance tests target the real UI) | 1d |
 
-Demo at end of phase: full RAG loop over REST on the demo site.
-
-## Phase 4 — Frontend (Volto modal UI)
-
-Goal: the user-facing MVP in `@kitconcept/volto-solr`.
-
-- [ ] **4.1 Short UX spec**: states (idle/loading/answer/error/disabled),
-      keyboard behavior (⌘K open, Esc close), AI-disclaimer copy, relation
-      to the existing search bar (open question 8). Wireframe level; review
-      with the team before building.
-- [ ] **4.2 Redux plumbing**: `actions/ragsearch/` + `reducers/ragsearch/`
-      calling `@rag-search` (pattern: existing `actions/solrsearch/`).
-- [ ] **4.3 Modal component**: command-palette modal
-      (`components/theme/`…): input, loading state, answer panel with
-      disclaimer, source list reusing the existing result-item rendering
-      from `SolrSearch`; graceful fallback link to classic search on error;
-      hidden entirely when the backend reports not-configured.
-- [ ] **4.4 Tests**: Jest component tests; one Cypress acceptance flow
-      against a mocked backend answer.
-- [ ] **4.5 i18n** for all new strings (existing i18n setup).
-
-Demo at end of phase: ⌘K on the demo site → ask → answer + sources. **This
-is the MVP.**
-
-## Phase 5 — Quality pass and evaluation tier 2
-
-Goal: decide the data-driven open questions; make quality trustworthy.
-
-- [ ] **5.1 Answer evaluation (RAGAS)**: faithfulness + answer relevancy on
-      the golden set, judge LLM on the same Ollama server; one-time human
-      calibration of the judge on a labeled sample.
-- [ ] **5.2 Hybrid retrieval, if the numbers demand it**: client-side RRF
-      (BM25 + knn, k=60) inside `@rag-search`; re-run the Phase 2 report to
-      confirm the gain. Designed to be swapped for Solr's native RRF
-      combiner when 9.11/10.1 ships.
-- [ ] **5.3 Tuning knobs pass**: `topK`, chunk size/overlap, prompt wording
-      — one iteration guided by the metrics, not more (MVP discipline).
-- [ ] **5.4 Acceptance thresholds**: fix the release criteria (proposal in
-      spec §7) with the measured baseline; wire the retrieval evaluation
-      into CI as a regression gate.
-
-## Phase 6 — Post-MVP roadmap (tracked, not scheduled)
-
-- Community LLM-connector add-on integration (requires upstream support for
-  the kitconcept Ollama server) → any-provider support.
-- Control-panel UI for kitconcept.solr configuration incl. AI credentials.
-- Multi-turn conversation; streaming answers; query rewriting; re-ranking;
-  attachments in the modal; model benchmarking across providers.
-- Multilingual optimization (per-language analyzers already exist for
-  keyword search; embedding side per open question 3).
+**Later roadmap** (tracked, not scheduled): full evaluation harness
+(Recall@k/MRR/nDCG as CI regression gate, RAGAS faithfulness/relevancy with
+calibrated judge — client-funded), admin configuration UI, community
+LLM-connector add-on integration, multi-turn conversation, streaming
+answers, query rewriting/re-ranking, German content rollout.
 
 ## Risks and mitigations
 
 | Risk | Impact | Mitigation |
 | --- | --- | --- |
-| Pure-vector retrieval quality insufficient on real corpora | wrong sources → wrong answers | Phase 2 measures it early; hybrid RRF is a bounded, planned fallback (5.2) |
-| Ollama server latency/availability | slow saves, hanging searches | strict timeouts everywhere; indexing never fails on embedding errors; frontend error state falls back to classic search |
-| Long-document embedding truncation (`num_ctx` default 2048) | silently bad vectors | chunking keeps inputs ~500 tokens; client always sets `num_ctx`; test asserts prefix+ctx behavior |
+| Pure-vector retrieval quality insufficient (hybrid deferred) | wrong sources → wrong answers | Step 2 questions surface it immediately; hybrid RRF (P1.1) is a bounded, planned add-on and moves up if needed |
+| LLM server latency/availability | slow saves, hanging searches | strict timeouts everywhere; indexing never fails on embedding errors; endpoint returns structured errors for graceful UI fallback |
+| 512-token sequence limit of the embedding model | silently truncated, bad vectors | ~400-token chunks; client sets `num_ctx` and detects/logs truncation |
 | Embedding model change invalidates index | broken search after model swap | model name recorded at index time; mismatch triggers/reports reindex need |
-| LLM hallucinates sources or answers beyond context | trust damage | prompt constraints; unanswerable questions in golden set; faithfulness metric in 5.1; UI disclaimer |
-| CI cannot run models | untestable feature | all CI tests run against mocked/deterministic endpoints; model-dependent evaluation is a separate opt-in job |
+| LLM hallucinates sources or answers beyond context | trust damage | prompt constraints; decline-when-unanswerable tested by Step 2 questions; UI disclaimer |
+| CI cannot run models | untestable feature | all CI tests run against mocked/deterministic endpoints; model-dependent checks are opt-in |
 | Editing latency from synchronous embedding | editor complaints | short timeout + skip-on-failure; batched full reindex; async queue is the documented plan B |
+| No stabilization buffer in the estimates | overruns land directly on the schedule | checkpoint after 5 dev days: re-evaluate the estimate, update the schedule if necessary |
 
-## Suggested working order (tight MVP path)
+## Working order
 
-Decisions 1/3/7 → 1.1–1.2 → 1.3–1.4 → 1.6 → 2.1–2.4 (overlapping) → 3.1–3.2
-→ 4.1–4.3 → 5.1/5.4, with 1.7/3.4/4.4 tests accompanying their phases. Each
-phase lands as one or more reviewed PRs referencing #79; towncrier news
+Kick-off prerequisites → Step 1 (foundations, then indexing) → Step 2
+(overlapping) → Step 3 → checkpoint bookkeeping → P1 when scheduled. Each
+step lands as one or more reviewed PRs referencing #79; towncrier news
 fragments per PR as usual.

--- a/SPECIFICATION-79.md
+++ b/SPECIFICATION-79.md
@@ -1,8 +1,8 @@
 # AI Search (RAG) — Specification
 
 Ticket: [#79](https://github.com/kitconcept/kitconcept.solr/issues/79)
-Status: draft for discussion
-Companion document: [IMPLEMENTATION-79.md](./IMPLEMENTATION-79.md)
+Status: **decisions final** (team review 2026-07-09); implementation planned per
+[IMPLEMENTATION-79.md](./IMPLEMENTATION-79.md)
 
 ## 1. Goals
 
@@ -16,7 +16,7 @@ The user-facing goal, as a user story:
 
 > As a user, I can ask a question in natural language. I get a natural-language
 > answer to my question, together with the list of documents within the site
-> that the answer was based on.
+> that the answer is based on.
 
 Design goals derived from that:
 
@@ -26,82 +26,105 @@ Design goals derived from that:
   content they are not allowed to see.
 - **Part of the product, off by default.** The feature ships inside
   `kitconcept.solr` (backend) and `@kitconcept/volto-solr` (frontend), not as a
-  separate plugin. It activates only when an LLM endpoint is configured; sites
-  that do not configure it are unaffected.
-- **Measurable quality.** "It works" is defined by an evaluation harness
-  (golden question set + retrieval metrics + answer grading), not by anecdote.
+  separate plugin. It activates only when an LLM endpoint is configured and the
+  toggle is on; sites that do not configure it are unaffected.
+- **Measurable quality.** The MVP ships with a small golden question set as
+  smoke-level checks; the full evaluation harness is a post-MVP work item
+  (see §7).
 
 ## 2. MVP scope
 
-The MVP is the smallest version that actually works end to end:
+The MVP is the smallest version that actually works end to end. This is a
+POC-grade scope: quality tooling and tuning are deliberately deferred.
 
 1. **Single-turn.** One question → one answer + source list. No conversation
    memory, no follow-up questions. A new question is a new query.
 2. The response contains exactly two things beyond a normal search response:
    the **summary answer** and the **source documents** (which are ordinary
    Solr results).
-3. **One model provider.** The MVP connects to a single Ollama-compatible
-   server (the kitconcept Ollama server) using two models:
-   an **embedding model** (`nomic-embed-text`) and a **general-purpose LLM**
-   for answer synthesis. No provider abstraction, no model switching UI.
-4. **Configuration without UI.** Endpoint URL, credentials and model names are
-   set in the kitconcept.solr configuration (Plone registry + environment
-   variables, see §5). No control-panel UI in the MVP.
-5. **Minimal modal UI.** A command-palette style (⌘K) modal with a question
-   input, an answer panel and the source result list (see §6).
-6. **Demo site + evaluation.** An example content corpus shipped as
-   export/import data, a golden set of questions, and scripts that measure
-   retrieval and answer quality (see §7).
+3. **One model provider, fixed models.** The MVP connects to the kitconcept
+   LLM server (Ollama-compatible) using two models, both fixed:
+   - embedding: **`nomic-embed-text-v2-moe`** (multilingual — chosen from the
+     start even though the MVP is English-only, so adding German content later
+     does not require a full reindex; its 512-token sequence limit makes
+     chunking mandatory and sets the chunk target to ~400 tokens);
+   - generation: **`qwen3:14b`** (model comparison is a post-MVP task).
+4. **Minimal configuration, no UI.** An **"AI search" toggle** plus the
+   endpoint URL/token via environment variables; model names and tuning
+   parameters are code defaults. The full configuration surface (registry
+   records for models, topK, chunk size, prompt override) is post-MVP. See §5.
+5. **One kind of chunking.** Two kinds of chunking have been identified for
+   the intranet use case; the MVP implements one, with the design kept
+   compatible with the second (post-MVP). See §8, open point 1.
+6. **No new search UI in this repository for the MVP.** The search modal UX
+   is developed separately in the kitconcept.intranet project; the RAG
+   backend is developed and tested over REST (with a throwaway input box at
+   most), and the finalized UX is integrated before the MVP ships. The
+   "AI search" toggle means RAG does not unconditionally replace the normal
+   search. See §6.
+7. **Test corpus + smoke checks.** A translated demo corpus with ~20
+   hand-written questions with expected sources (see §7).
 
 ### Explicitly out of scope for the MVP (post-MVP roadmap)
 
-- Multi-turn chat / conversation context.
-- Admin/control-panel UI for AI configuration (long-term we want a UI for
-  kitconcept.solr configuration in general; the AI credentials are a prime
-  candidate).
-- Integration with the community LLM-connector add-on. Long-term we commit to
-  using it (it gives us any-provider support); it first needs support for the
-  kitconcept Ollama setup. For the MVP we connect directly.
-- Attaching files/context to a query, search-mode toggles, suggested actions
-  in the modal.
-- Streaming/token-by-token answer display (nice to have; the MVP may render
-  the answer only when complete).
-- Answer quality tuning beyond the initial evaluation pass (re-ranking models,
-  semantic chunking, query rewriting, multilingual optimization).
+- **Hybrid retrieval (BM25 + vector, RRF)** — deferred from the MVP by the
+  re-scoping decision; it is the *first* post-MVP work item, and the query
+  layer is factored so it is a bounded add-on. The pure-knn MVP results
+  should confirm the deferral is acceptable (earlier experiments suggested
+  pure vector search may not be sufficient — see §3).
+- The second kind of chunking.
+- Full test pass (beyond minimal inline coverage accompanying the MVP PRs)
+  and acceptance/CI wiring — acceptance tests are deferred until the real
+  search UI is integrated, so they target that UI rather than a throwaway
+  input box.
+- Full evaluation harness (Recall@k/MRR, nDCG, RAGAS faithfulness/relevancy)
+  — to be funded by client projects.
+- Generation model comparison (`qwen3:14b` vs `qwen3.5:9b-q8_0` vs others).
+- Full configuration surface (registry records) and an admin/control-panel
+  UI for AI configuration.
+- Multi-turn chat / conversation context; streaming answers.
+- Integration with the community LLM-connector add-on. Long-term we commit
+  to using it (it gives us any-provider support); it first needs support for
+  the kitconcept Ollama setup. For the MVP we connect directly.
+- Sharing the demo corpus export/import dump with this repository's CI.
+- German content rollout (the architecture is German-ready via the
+  multilingual embedding model).
 
 ## 3. Architecture overview
 
 ```
                        ┌──────────────────────────────────────────┐
                        │                Volto (React)             │
-                       │   ⌘K modal → question                    │
+                       │   search UI (external project) → question│
                        └───────────────┬──────────────────────────┘
                                        │ GET/POST @rag-search?q=...
                        ┌───────────────▼──────────────────────────┐
                        │        Plone / kitconcept.solr           │
                        │  1. embed(question)  ──────────────────────────┐
-                       │  2. Solr retrieval (knn [+ BM25/RRF])    │      │
-                       │  3. build prompt(question, top docs)     │      │
+                       │  2. Solr retrieval ({!knn})              │      │
+                       │  3. build prompt(question, top chunks)   │      │
                        │  4. LLM completion  ───────────────────────────┤
                        │  5. return {answer, sources[]}           │      │
                        └───────────────┬──────────────────────────┘      │
                                        │ {!knn f=content_vector}         │
-                       ┌───────────────▼─────────────┐   ┌───────────────▼─────────────┐
-                       │        Solr 9.10            │   │   Ollama server (kitconcept) │
-                       │  content_vector (768, HNSW) │   │  /api/embed  nomic-embed-text│
-                       │  existing keyword fields    │   │  /api/chat   general LLM     │
+                       ┌───────────────▼─────────────┐   ┌───────────────▼──────────────┐
+                       │        Solr 9.10            │   │  kitconcept LLM server       │
+                       │  content_vector (768, HNSW) │   │  /api/embed                  │
+                       │  chunk sibling documents    │   │    nomic-embed-text-v2-moe   │
+                       │  existing keyword fields    │   │  /api/chat   qwen3:14b       │
                        └─────────────────────────────┘   └──────────────────────────────┘
 ```
 
-Two distinct LLM endpoints are involved (same Ollama server):
+Two distinct LLM endpoints are involved (same server):
 
-- **Embedding endpoint** — used at *indexing time* (vectorize content) and at
-  *query time* (vectorize the user's question). Ollama `POST /api/embed`,
-  which batches inputs and returns L2-normalized vectors.
+- **Embedding endpoint** — used at *indexing time* (vectorize content chunks)
+  and at *query time* (vectorize the user's question). Ollama
+  `POST /api/embed`, which batches inputs and returns L2-normalized vectors.
 - **Generation endpoint** — used at *query time only*: receives one prompt
-  containing (a) the user's question, (b) the retrieved document texts, and
-  (c) fixed instructions ("answer the question based only on these documents,
-  cite which documents you used"), and returns the summary answer.
+  containing (a) the user's question, (b) the retrieved chunk texts (with
+  parent title/URL), and (c) fixed instructions ("answer the question based
+  only on these documents, cite which documents you used"), and returns the
+  summary answer.
 
 ### Existing groundwork
 
@@ -111,8 +134,9 @@ unpopulated and unqueried:
 - `solr/etc/conf/schema.xml`: field type `knn_vector_768`
   (`solr.DenseVectorField`, `vectorDimension="768"`,
   `similarityFunction="dot_product"`) and field `content_vector`.
-- `nomic-embed-text` produces 768-dim vectors; `/api/embed` returns them
-  normalized, so `dot_product` is equivalent to cosine similarity here.
+- `nomic-embed-text-v2-moe` produces 768-dim vectors; `/api/embed` returns
+  them normalized, so `dot_product` is equivalent to cosine similarity here.
+  **Decision: keep `dot_product`, no schema change.**
 
 ### Retrieval design
 
@@ -124,31 +148,39 @@ unpopulated and unqueried:
   with vector search.
 - **Hybrid search** (BM25 + vector, fused with Reciprocal Rank Fusion) is the
   industry-standard remedy for pure-vector weaknesses (exact names, codes,
-  jargon; BEIR shows dense retrieval underperforms BM25 out-of-domain).
+  jargon; BEIR shows dense retrieval underperforms BM25 out-of-domain), and
+  earlier hands-on experiments on intranet content pointed the same way.
+  It is nevertheless **deferred to post-MVP** by the re-scoping decision.
   Native RRF lands in Solr 9.11/10.1 ([SOLR-17319]) which is **not released
-  yet**, so if/when we need hybrid we fuse client-side (two Solr requests,
-  `score = Σ 1/(60 + rank)`), which is drop-in replaceable by the native
-  combiner later. The MVP starts with pure knn retrieval and the evaluation
-  harness decides whether hybrid is required (see §8 open question 2).
+  yet**, so the post-MVP implementation fuses client-side (two Solr requests,
+  `score = Σ 1/(60 + rank)`), drop-in replaceable by the native combiner
+  later. The MVP query layer is factored so this is a bounded add-on.
 
 [SOLR-17319]: https://issues.apache.org/jira/browse/SOLR-17319
 
 ### Indexing design
 
-- Embeddings are computed **on the Plone side** (client of Ollama), not via
-  Solr's built-in LLM module: the module doesn't support Ollama as a provider
-  and cannot add the task prefixes `nomic-embed-text` requires
+- Embeddings are computed **on the Plone side** (client of the LLM server),
+  not via Solr's built-in LLM module: the module doesn't support Ollama as a
+  provider and cannot add the task prefixes the nomic models require
   (`search_document: …` for content, `search_query: …` for questions —
   skipping them measurably degrades retrieval).
-- **Chunking**: embedding a whole long document produces a "blurry" vector.
-  State of the art for long-form documentation is structure-aware chunking:
-  split on headings/blocks at roughly **500 tokens per chunk with 10–15%
-  overlap**, merging tiny fragments. Volto blocks give us structural
-  boundaries for free (the existing block-text indexer already walks them).
-- Chunk storage in Solr — see §8 open question 1; the recommended model is
-  chunks as **sibling documents** (`parent_uid` + denormalized title/path/
-  security fields), grouped back to parent documents at query time
-  (parent-document retrieval: match a chunk, show the parent as the source).
+- **Chunking**: embedding a whole long document produces a "blurry" vector,
+  and `nomic-embed-text-v2-moe`'s 512-token sequence limit makes chunking
+  mandatory. Structure-aware chunking: split on headings/blocks at roughly
+  **400 tokens per chunk with 10–15% overlap**, merging tiny fragments.
+  Volto blocks give us structural boundaries for free (the existing
+  block-text indexer already walks them). The embedding client must detect
+  and log truncation rather than silently accept it.
+- **Chunk storage (decided)**: chunks as **sibling documents** in Solr
+  (`parent_uid` + denormalized title/path/security fields), grouped back to
+  parent documents at query time (parent-document retrieval: match a chunk,
+  show the parent as the source). Nested/block-join documents were rejected:
+  atomic block reindexing conflicts with Plone's per-object indexing, and
+  knn-through-block-join is Solr 10.x-only.
+- **Index-time embedding is synchronous (decided)** with a short timeout;
+  embedding failure must never fail the content save (log + skip vectors).
+  An async queue is the documented plan B if editing latency hurts.
 
 ## 4. Functional specification
 
@@ -158,8 +190,9 @@ unpopulated and unqueried:
   (`backend/src/kitconcept/solr/services/`).
 - Request: the question string, plus optional standard search parameters
   (`path_prefix`, `lang`) reused from `@solr`.
-- Behavior: embed question → retrieve top-K chunks/documents (security
-  trimmed) → collapse to parent documents → prompt LLM → respond.
+- Behavior: embed question → retrieve top-K chunks (security trimmed) →
+  collapse to parent documents → prompt LLM with the matched chunks →
+  respond.
 - Response (shape, subject to refinement in implementation):
 
 ```json
@@ -172,9 +205,12 @@ unpopulated and unqueried:
 
 - Errors (LLM endpoint down, timeout, not configured) return a structured
   error so the frontend can degrade gracefully to normal search.
-- If the feature is not configured, the endpoint returns 501/`not configured`
-  and the frontend never offers the AI mode.
-- Timeouts are mandatory on both Ollama calls; the endpoint must never hang a
+- If the feature is not configured/enabled, the endpoint returns a structured
+  `not configured` response and the frontend never offers the AI mode.
+- The prompt instructs the model to answer only from the provided context,
+  answer in the language of the question, and decline explicitly when the
+  answer is not found in the documentation.
+- Timeouts are mandatory on both LLM calls; the endpoint must never hang a
   Plone thread indefinitely.
 
 ### Indexing behavior
@@ -184,158 +220,93 @@ unpopulated and unqueried:
   are written to Solr alongside the document.
 - On delete/unindex, chunks are removed with the parent.
 - A full-reindex path exists (`solr-activate-and-reindex`) and must populate
-  vectors; the embedding model name is recorded so a model change forces a
-  reindex.
+  vectors using batched `/api/embed` calls; the embedding model name is
+  recorded so a model change forces a reindex.
 - If the embedding endpoint is unavailable at indexing time, indexing of the
   document must still succeed (log + skip vectors) — search availability must
   not depend on the AI stack.
 
 ## 5. Configuration
 
-Two layers, consistent with how kitconcept.solr is configured today:
+MVP configuration is deliberately minimal:
 
-- **Plone registry** (`IKitconceptSolrSettings`,
-  `backend/src/kitconcept/solr/interfaces.py` + GenericSetup profile):
-  feature toggle (per the epic: "as Admin I can turn it on or off"), model
-  names, prompt template override, `topK`, chunk size parameters.
-- **Environment variables** (secrets / deployment-specific): Ollama base URL
-  and API credentials (e.g. `KITCONCEPT_SOLR_LLM_URL`,
-  `KITCONCEPT_SOLR_LLM_TOKEN`), following the existing
-  `COLLECTIVE_SOLR_HOST`/`COLLECTIVE_SOLR_BASE` pattern in
+- **"AI search" toggle** (Plone registry, `IKitconceptSolrSettings` in
+  `backend/src/kitconcept/solr/interfaces.py` + GenericSetup profile) — per
+  the epic requirement: "as Admin I can turn it on or off".
+- **Endpoint URL + token via environment variables** (e.g.
+  `KITCONCEPT_SOLR_LLM_URL`, `KITCONCEPT_SOLR_LLM_TOKEN`), following the
+  existing `COLLECTIVE_SOLR_HOST`/`COLLECTIVE_SOLR_BASE` pattern in
   `docker-compose.yml`. Credentials must not live in the registry (they end
   up in exported site configuration).
+- **Everything else is a code default**: model names
+  (`nomic-embed-text-v2-moe`, `qwen3:14b`), topK, chunk size/overlap, prompt
+  template.
 
-No UI in the MVP. The feature counts as **enabled** when the toggle is on and
-the endpoint variables are present.
+Post-MVP: registry records for model names, topK, chunk size and prompt
+override; longer-term an admin UI. The feature counts as **enabled** when the
+toggle is on and the endpoint variables are present.
 
-## 6. Search UI (Volto)
+## 6. Search UI
 
-MVP: a **modal search** (command-palette pattern, as in e.g. the Tailwind
-docs ⌘K dialog), replacing/augmenting the current search entry point in
-`@kitconcept/volto-solr`:
+**The search UX is not part of this repository's MVP scope.** The search
+modal (command-palette pattern) is being designed and implemented separately
+in the kitconcept.intranet project; the RAG feature integrates into it before
+the MVP ships. Decisions that affect this repository:
 
-- Opened via keyboard shortcut (⌘K / Ctrl-K) and via the search icon.
-- One text input. Submitting triggers `@rag-search`.
-- Result view: answer panel (with a visible "AI-generated — verify against
-  the sources" hint) above the source document list (reusing the existing
-  result-item rendering).
-- Loading state while the LLM answers (several seconds); error state falls
-  back to a link to the classic search.
-- The classic `@solr` search remains fully functional and unchanged.
+- There will be an **"AI search" toggle in the search UI** — RAG does not
+  unconditionally replace the normal search; the classic `@solr` search
+  remains fully functional and unchanged.
+- During backend development, testing happens over REST (optionally a
+  throwaway input box); no acceptance tests are written against interim UI.
+- The answer panel must carry a visible "AI-generated — verify against the
+  sources" hint; error states fall back to the classic search.
 
-A short UX specification (wireframe-level: states, keyboard behavior, copy)
-is a deliverable of the implementation phase — the modal is deliberately
-minimal but the pattern is chosen because it extends naturally (mode toggles,
-attachments) post-MVP.
+## 7. Test corpus and quality checks
 
-## 7. Demo site, example questions, evaluation
+MVP-level (this is a POC — minimal by decision):
 
-How we know the results are "good", aligned with current industry practice:
+- **Corpus**: existing German template demo content (translated to English),
+  imported into the kitconcept.intranet demo site. Research confirmed no
+  suitable open intranet-shaped corpus with ready-made questions exists
+  (public QA datasets are Wikipedia/web-shaped; open handbooks have no
+  questions), so a translated in-house corpus plus hand-written questions is
+  the pragmatic and correct choice. English first; German later with
+  expected-similar results (the embedding model is already multilingual).
+- **Questions**: ~20 hand-written questions with expected source documents,
+  stored alongside the corpus; used as smoke tests ("are the right documents
+  found? does the answer decline when it should?").
+- The demo site lives in the kitconcept.intranet project; making the same
+  export/import dump also drive this repository's CI tests is post-MVP.
 
-### Demo corpus
+Post-MVP (client-funded): the full evaluation harness — golden set grown to
+100+ questions (CRAG-style type coverage incl. unanswerable), retrieval
+metrics (Recall@5/10, MRR, nDCG@10 via `ranx`/`pytrec_eval`) as a CI
+regression gate, RAGAS faithfulness/answer-relevancy with a calibrated LLM
+judge, and model comparisons.
 
-A demo/example site is shipped with the product as export/import data (also
-useful beyond this feature). Recommended content, based on a license/quality
-survey:
+## 8. Decisions record and open points
 
-- **Primary: a synthetic fictional-organization corpus** (~50–150 documents:
-  HR policies, IT procedures, onboarding guides, org structure), generated
-  with an LLM and human-reviewed. Two decisive advantages: no license burden,
-  and **no training-data contamination** — the answer LLM cannot answer from
-  memory, so a correct, correctly-sourced answer proves the retrieval
-  actually works. (Established practice; cf. EnterpriseRAG-Bench, OrgForge.)
-- **Alternative/supplement: a curated subset of the GitLab Handbook**
-  (CC BY-SA 4.0, real intranet-genre content, English) — believable, but
-  contaminated (it is in every LLM's training data), so evaluation must check
-  *sources*, not just answer text.
-- German content (relevant for the target market): note that
-  `nomic-embed-text` is English-trained; the multilingual variant is
-  `nomic-embed-text-v2-moe` (also 768-dim, Apache-2.0, on Ollama). See §8
-  open question 3. Public-domain German federal law texts
-  (github.com/bundestag/gesetze) are a safe authentic supplement;
-  `deepset/germanquad` (CC BY 4.0) provides a ready German corpus+QA set for
-  pipeline benchmarking.
+All major open questions from the draft phase have been decided (team review
+2026-07-09):
 
-### Golden question set
+| # | Question | Decision |
+| --- | --- | --- |
+| 1 | Chunk storage model in Solr | Sibling documents with `parent_uid` + denormalized security fields; parent-collapse at query time |
+| 2 | Pure vector vs. hybrid in the MVP | **Hybrid deferred to post-MVP** (first follow-up item); MVP is pure knn, factored so RRF fusion is a bounded add-on |
+| 3 | Embedding model / multilinguality | `nomic-embed-text-v2-moe` from the start; chunk target ~400 tokens (512-token limit) |
+| 4 | Index-time embedding | Synchronous, skip-on-failure; async queue only if editing latency demands it |
+| 5 | Generation model | `qwen3:14b` fixed for the MVP; comparison post-MVP |
+| 6 | Similarity function | `dot_product` (existing schema, no change) |
+| 7 | Demo corpus | Translated German template content + ~20 hand-written questions; English first |
+| 8 | Search UX | External (kitconcept.intranet search modal project); "AI search" toggle |
+| 9 | Chunk vs. document context for the prompt | Prompt with matched chunks (+ parent title/URL), cite parents |
 
-- **30–50 questions to start** (growing later toward 100+), stored in the
-  repo as `question / expected source document(s) / reference answer`
-  triples.
-- Question types follow the CRAG taxonomy: simple factual, comparison,
-  aggregation, multi-hop, and questions with **no answer in the corpus**
-  (the system should say so rather than hallucinate).
-- Bootstrapped with a generator (RAGAS `TestsetGenerator` with personas —
-  "new employee", "HR admin"), then **manually reviewed and culled**; plus
-  hand-written terse real-user-style queries.
+Remaining open point:
 
-### Metrics — two tiers
-
-1. **Retrieval metrics** (deterministic, no LLM, cheap — CI-able): run the
-   golden questions against the retrieval endpoint and compute
-   **Recall@5/10, MRR, nDCG@10** (`ranx` or `pytrec_eval`). This directly
-   answers "are the correct source documents found?" — the MVP success
-   criterion from the kickoff ("we actually get the documents that make
-   sense for that question").
-2. **Answer metrics** (LLM-as-judge, run on demand/nightly): **faithfulness**
-   (is every claim grounded in the retrieved sources?) and **answer
-   relevancy**, via **RAGAS** (Apache-2.0, vendor-neutral, any judge LLM —
-   can use the same Ollama server). Judge scores are calibrated against a
-   one-time human-labeled sample before being trusted for trend-tracking.
-
-MVP acceptance target (proposal, to be confirmed once baseline numbers
-exist): Recall@10 ≥ 0.8 on the golden set for answerable questions, and no
-hallucinated sources; answers for unanswerable questions must decline.
-
-## 8. Open questions / decisions still to be made
-
-Ordered by how early they block implementation. Each has a recommended
-default from the research phase.
-
-1. **Chunk storage model in Solr.** (a) chunks as sibling documents with
-   `parent_uid` + denormalized security fields, parent-collapse at query
-   time — flexible, works on Solr 9.x, plays well with Plone's per-object
-   reindexing; (b) nested child documents/block-join — poor fit (atomic
-   block reindexing conflicts with Plone; knn-through-block-join is Solr
-   10.x); (c) MVP-minimal: no chunks at all — one truncated-document vector
-   in the existing `content_vector` field, accepting blurry retrieval on
-   long documents. **Recommendation: (a)**; (c) is acceptable only as a
-   phase-1 stepping stone. *Blocks Phase 1.*
-2. **Pure vector vs. hybrid retrieval in the MVP.** Hybrid (client-side RRF)
-   is the industry default and the likely end state, but it doubles the
-   query path. **Recommendation: implement pure knn first, keep the query
-   layer factored so client-side RRF is a bounded add-on in the quality
-   phase, decided by golden-set numbers.** *Decided by Phase 5 data.*
-3. **Embedding model / multilinguality.** `nomic-embed-text` (English) vs
-   `nomic-embed-text-v2-moe` (multilingual incl. German, same 768 dims).
-   If German content is in MVP scope, v2-moe from the start avoids a full
-   reindex later; requires confirming it is available on the kitconcept
-   Ollama server. **Recommendation: confirm German requirements now; prefer
-   v2-moe if the server can host it.** *Blocks Phase 1 (index format).*
-4. **Embedding at indexing time: synchronous vs. queued.** Synchronous (in
-   the indexer/subscriber) is simple but adds an HTTP call per document to
-   every save and couples editing latency to the Ollama server. A queue
-   (async worker) is more robust but more moving parts. **Recommendation:
-   synchronous with a short timeout and skip-on-failure for the MVP; batch
-   endpoint for full reindexes. Revisit if editing latency hurts.**
-5. **Generation model choice.** Which general-purpose LLM on the kitconcept
-   Ollama server (quality vs. latency; answer language must follow the
-   question language). Needs a quick bake-off on the golden set. *Phase 3.*
-6. **Similarity function.** Schema says `dot_product`; nomic via `/api/embed`
-   returns normalized vectors, so it is equivalent to cosine. Keep
-   `dot_product` (no change) unless we switch to a model with unnormalized
-   outputs. *Effectively decided; recorded for the record.*
-7. **Demo corpus language and content** (see §7): synthetic fictional org
-   (which language(s)?) vs GitLab Handbook subset. **Recommendation:
-   synthetic, English first unless German is required for the first demo.**
-   *Blocks Phase 2.*
-8. **UX details of the modal**: trigger points (does it fully replace the
-   search bar?), mobile behavior, wording of the AI disclaimer, behavior
-   when the feature is disabled. Needs the short UX spec. *Blocks Phase 4.*
-9. **Chunk-level vs document-level context for the LLM prompt**: send parent
-   documents or the matched chunks (parent-document retrieval suggests:
-   retrieve by chunk, prompt with chunk + surrounding context, cite parent).
-   **Recommendation: prompt with matched chunks (+ title/URL), cite
-   parents.** *Phase 3.*
+1. **The two kinds of chunking.** Two kinds of chunking have been identified
+   for the intranet use case; details are to be clarified at implementation
+   kick-off. The MVP implements one kind; the design must stay compatible
+   with the second (post-MVP follow-up).
 
 ## 9. References
 
@@ -346,7 +317,7 @@ ticket):
 - Solr native RRF (unreleased, 9.11/10.1): https://issues.apache.org/jira/browse/SOLR-17319
 - RRF (Cormack et al. 2009): https://dl.acm.org/doi/10.1145/1571941.1572114
 - BEIR benchmark (dense vs BM25 out-of-domain): https://github.com/beir-cellar/beir
-- nomic-embed-text (prefixes, /api/embed, num_ctx): https://ollama.com/library/nomic-embed-text · https://docs.ollama.com/capabilities/embeddings
+- nomic embeddings (prefixes, /api/embed, num_ctx): https://docs.ollama.com/capabilities/embeddings
 - nomic-embed-text-v2-moe (multilingual): https://ollama.com/library/nomic-embed-text-v2-moe
 - Chunking practice: https://www.firecrawl.dev/blog/best-chunking-strategies-rag · https://weaviate.io/blog/chunking-strategies-for-rag
 - RAGAS (metrics + testset generation): https://docs.ragas.io/
@@ -354,6 +325,3 @@ ticket):
 - Golden-set / eval practice: https://hamel.dev/blog/posts/evals-faq/
 - CRAG question taxonomy: https://arxiv.org/abs/2406.04744
 - RAGBench (CC BY 4.0): https://huggingface.co/datasets/galileo-ai/ragbench
-- GitLab Handbook license: https://about.gitlab.com/blog/our-handbook-is-open-source-heres-why/
-- GermanQuAD: https://huggingface.co/datasets/deepset/germanquad
-- German law corpus: https://github.com/bundestag/gesetze

--- a/SPECIFICATION-79.md
+++ b/SPECIFICATION-79.md
@@ -1,0 +1,359 @@
+# AI Search (RAG) — Specification
+
+Ticket: [#79](https://github.com/kitconcept/kitconcept.solr/issues/79)
+Status: draft for discussion
+Companion document: [IMPLEMENTATION-79.md](./IMPLEMENTATION-79.md)
+
+## 1. Goals
+
+Enhance `kitconcept.solr` with an AI-powered search feature based on **RAG
+(Retrieval-Augmented Generation)**, targeted at sites with large amounts of
+long-form documentation (the primary driver is the kitconcept intranet
+distribution, where users need to quickly find answers inside abundant
+organizational documentation and fact-check them against the source pages).
+
+The user-facing goal, as a user story:
+
+> As a user, I can ask a question in natural language. I get a natural-language
+> answer to my question, together with the list of documents within the site
+> that the answer was based on.
+
+Design goals derived from that:
+
+- **Trustable answers.** The answer is always accompanied by its source
+  documents, so it can be fact-checked. The retrieval layer respects the
+  existing permission model — a user can never get an answer derived from
+  content they are not allowed to see.
+- **Part of the product, off by default.** The feature ships inside
+  `kitconcept.solr` (backend) and `@kitconcept/volto-solr` (frontend), not as a
+  separate plugin. It activates only when an LLM endpoint is configured; sites
+  that do not configure it are unaffected.
+- **Measurable quality.** "It works" is defined by an evaluation harness
+  (golden question set + retrieval metrics + answer grading), not by anecdote.
+
+## 2. MVP scope
+
+The MVP is the smallest version that actually works end to end:
+
+1. **Single-turn.** One question → one answer + source list. No conversation
+   memory, no follow-up questions. A new question is a new query.
+2. The response contains exactly two things beyond a normal search response:
+   the **summary answer** and the **source documents** (which are ordinary
+   Solr results).
+3. **One model provider.** The MVP connects to a single Ollama-compatible
+   server (the kitconcept Ollama server) using two models:
+   an **embedding model** (`nomic-embed-text`) and a **general-purpose LLM**
+   for answer synthesis. No provider abstraction, no model switching UI.
+4. **Configuration without UI.** Endpoint URL, credentials and model names are
+   set in the kitconcept.solr configuration (Plone registry + environment
+   variables, see §5). No control-panel UI in the MVP.
+5. **Minimal modal UI.** A command-palette style (⌘K) modal with a question
+   input, an answer panel and the source result list (see §6).
+6. **Demo site + evaluation.** An example content corpus shipped as
+   export/import data, a golden set of questions, and scripts that measure
+   retrieval and answer quality (see §7).
+
+### Explicitly out of scope for the MVP (post-MVP roadmap)
+
+- Multi-turn chat / conversation context.
+- Admin/control-panel UI for AI configuration (long-term we want a UI for
+  kitconcept.solr configuration in general; the AI credentials are a prime
+  candidate).
+- Integration with the community LLM-connector add-on. Long-term we commit to
+  using it (it gives us any-provider support); it first needs support for the
+  kitconcept Ollama setup. For the MVP we connect directly.
+- Attaching files/context to a query, search-mode toggles, suggested actions
+  in the modal.
+- Streaming/token-by-token answer display (nice to have; the MVP may render
+  the answer only when complete).
+- Answer quality tuning beyond the initial evaluation pass (re-ranking models,
+  semantic chunking, query rewriting, multilingual optimization).
+
+## 3. Architecture overview
+
+```
+                       ┌──────────────────────────────────────────┐
+                       │                Volto (React)             │
+                       │   ⌘K modal → question                    │
+                       └───────────────┬──────────────────────────┘
+                                       │ GET/POST @rag-search?q=...
+                       ┌───────────────▼──────────────────────────┐
+                       │        Plone / kitconcept.solr           │
+                       │  1. embed(question)  ──────────────────────────┐
+                       │  2. Solr retrieval (knn [+ BM25/RRF])    │      │
+                       │  3. build prompt(question, top docs)     │      │
+                       │  4. LLM completion  ───────────────────────────┤
+                       │  5. return {answer, sources[]}           │      │
+                       └───────────────┬──────────────────────────┘      │
+                                       │ {!knn f=content_vector}         │
+                       ┌───────────────▼─────────────┐   ┌───────────────▼─────────────┐
+                       │        Solr 9.10            │   │   Ollama server (kitconcept) │
+                       │  content_vector (768, HNSW) │   │  /api/embed  nomic-embed-text│
+                       │  existing keyword fields    │   │  /api/chat   general LLM     │
+                       └─────────────────────────────┘   └──────────────────────────────┘
+```
+
+Two distinct LLM endpoints are involved (same Ollama server):
+
+- **Embedding endpoint** — used at *indexing time* (vectorize content) and at
+  *query time* (vectorize the user's question). Ollama `POST /api/embed`,
+  which batches inputs and returns L2-normalized vectors.
+- **Generation endpoint** — used at *query time only*: receives one prompt
+  containing (a) the user's question, (b) the retrieved document texts, and
+  (c) fixed instructions ("answer the question based only on these documents,
+  cite which documents you used"), and returns the summary answer.
+
+### Existing groundwork
+
+The Solr schema (since 2.0.0a14) already defines the vector field — currently
+unpopulated and unqueried:
+
+- `solr/etc/conf/schema.xml`: field type `knn_vector_768`
+  (`solr.DenseVectorField`, `vectorDimension="768"`,
+  `similarityFunction="dot_product"`) and field `content_vector`.
+- `nomic-embed-text` produces 768-dim vectors; `/api/embed` returns them
+  normalized, so `dot_product` is equivalent to cosine similarity here.
+
+### Retrieval design
+
+- Query-time vector search uses Solr's `{!knn f=content_vector topK=K}` query
+  parser (available since Solr 9.0; we ship 9.10).
+- **Security filtering keeps working**: when the knn query is the main query,
+  Solr applies `fq` filters as HNSW *pre-filters* — the existing
+  `allowedRolesAndUsers` trimming, path and language filters compose correctly
+  with vector search.
+- **Hybrid search** (BM25 + vector, fused with Reciprocal Rank Fusion) is the
+  industry-standard remedy for pure-vector weaknesses (exact names, codes,
+  jargon; BEIR shows dense retrieval underperforms BM25 out-of-domain).
+  Native RRF lands in Solr 9.11/10.1 ([SOLR-17319]) which is **not released
+  yet**, so if/when we need hybrid we fuse client-side (two Solr requests,
+  `score = Σ 1/(60 + rank)`), which is drop-in replaceable by the native
+  combiner later. The MVP starts with pure knn retrieval and the evaluation
+  harness decides whether hybrid is required (see §8 open question 2).
+
+[SOLR-17319]: https://issues.apache.org/jira/browse/SOLR-17319
+
+### Indexing design
+
+- Embeddings are computed **on the Plone side** (client of Ollama), not via
+  Solr's built-in LLM module: the module doesn't support Ollama as a provider
+  and cannot add the task prefixes `nomic-embed-text` requires
+  (`search_document: …` for content, `search_query: …` for questions —
+  skipping them measurably degrades retrieval).
+- **Chunking**: embedding a whole long document produces a "blurry" vector.
+  State of the art for long-form documentation is structure-aware chunking:
+  split on headings/blocks at roughly **500 tokens per chunk with 10–15%
+  overlap**, merging tiny fragments. Volto blocks give us structural
+  boundaries for free (the existing block-text indexer already walks them).
+- Chunk storage in Solr — see §8 open question 1; the recommended model is
+  chunks as **sibling documents** (`parent_uid` + denormalized title/path/
+  security fields), grouped back to parent documents at query time
+  (parent-document retrieval: match a chunk, show the parent as the source).
+
+## 4. Functional specification
+
+### New REST endpoint: `@rag-search`
+
+- Registered like the existing `@solr` service
+  (`backend/src/kitconcept/solr/services/`).
+- Request: the question string, plus optional standard search parameters
+  (`path_prefix`, `lang`) reused from `@solr`.
+- Behavior: embed question → retrieve top-K chunks/documents (security
+  trimmed) → collapse to parent documents → prompt LLM → respond.
+- Response (shape, subject to refinement in implementation):
+
+```json
+{
+  "answer": "Employees are entitled to at least 30 days of leave…",
+  "sources": [ { "@id": "...", "title": "...", "description": "...", "snippet": "..." } ],
+  "error": null
+}
+```
+
+- Errors (LLM endpoint down, timeout, not configured) return a structured
+  error so the frontend can degrade gracefully to normal search.
+- If the feature is not configured, the endpoint returns 501/`not configured`
+  and the frontend never offers the AI mode.
+- Timeouts are mandatory on both Ollama calls; the endpoint must never hang a
+  Plone thread indefinitely.
+
+### Indexing behavior
+
+- On indexing/reindexing a content object, its extracted text (the existing
+  `SearchableText`/block text path) is chunked and embedded, and the chunks
+  are written to Solr alongside the document.
+- On delete/unindex, chunks are removed with the parent.
+- A full-reindex path exists (`solr-activate-and-reindex`) and must populate
+  vectors; the embedding model name is recorded so a model change forces a
+  reindex.
+- If the embedding endpoint is unavailable at indexing time, indexing of the
+  document must still succeed (log + skip vectors) — search availability must
+  not depend on the AI stack.
+
+## 5. Configuration
+
+Two layers, consistent with how kitconcept.solr is configured today:
+
+- **Plone registry** (`IKitconceptSolrSettings`,
+  `backend/src/kitconcept/solr/interfaces.py` + GenericSetup profile):
+  feature toggle (per the epic: "as Admin I can turn it on or off"), model
+  names, prompt template override, `topK`, chunk size parameters.
+- **Environment variables** (secrets / deployment-specific): Ollama base URL
+  and API credentials (e.g. `KITCONCEPT_SOLR_LLM_URL`,
+  `KITCONCEPT_SOLR_LLM_TOKEN`), following the existing
+  `COLLECTIVE_SOLR_HOST`/`COLLECTIVE_SOLR_BASE` pattern in
+  `docker-compose.yml`. Credentials must not live in the registry (they end
+  up in exported site configuration).
+
+No UI in the MVP. The feature counts as **enabled** when the toggle is on and
+the endpoint variables are present.
+
+## 6. Search UI (Volto)
+
+MVP: a **modal search** (command-palette pattern, as in e.g. the Tailwind
+docs ⌘K dialog), replacing/augmenting the current search entry point in
+`@kitconcept/volto-solr`:
+
+- Opened via keyboard shortcut (⌘K / Ctrl-K) and via the search icon.
+- One text input. Submitting triggers `@rag-search`.
+- Result view: answer panel (with a visible "AI-generated — verify against
+  the sources" hint) above the source document list (reusing the existing
+  result-item rendering).
+- Loading state while the LLM answers (several seconds); error state falls
+  back to a link to the classic search.
+- The classic `@solr` search remains fully functional and unchanged.
+
+A short UX specification (wireframe-level: states, keyboard behavior, copy)
+is a deliverable of the implementation phase — the modal is deliberately
+minimal but the pattern is chosen because it extends naturally (mode toggles,
+attachments) post-MVP.
+
+## 7. Demo site, example questions, evaluation
+
+How we know the results are "good", aligned with current industry practice:
+
+### Demo corpus
+
+A demo/example site is shipped with the product as export/import data (also
+useful beyond this feature). Recommended content, based on a license/quality
+survey:
+
+- **Primary: a synthetic fictional-organization corpus** (~50–150 documents:
+  HR policies, IT procedures, onboarding guides, org structure), generated
+  with an LLM and human-reviewed. Two decisive advantages: no license burden,
+  and **no training-data contamination** — the answer LLM cannot answer from
+  memory, so a correct, correctly-sourced answer proves the retrieval
+  actually works. (Established practice; cf. EnterpriseRAG-Bench, OrgForge.)
+- **Alternative/supplement: a curated subset of the GitLab Handbook**
+  (CC BY-SA 4.0, real intranet-genre content, English) — believable, but
+  contaminated (it is in every LLM's training data), so evaluation must check
+  *sources*, not just answer text.
+- German content (relevant for the target market): note that
+  `nomic-embed-text` is English-trained; the multilingual variant is
+  `nomic-embed-text-v2-moe` (also 768-dim, Apache-2.0, on Ollama). See §8
+  open question 3. Public-domain German federal law texts
+  (github.com/bundestag/gesetze) are a safe authentic supplement;
+  `deepset/germanquad` (CC BY 4.0) provides a ready German corpus+QA set for
+  pipeline benchmarking.
+
+### Golden question set
+
+- **30–50 questions to start** (growing later toward 100+), stored in the
+  repo as `question / expected source document(s) / reference answer`
+  triples.
+- Question types follow the CRAG taxonomy: simple factual, comparison,
+  aggregation, multi-hop, and questions with **no answer in the corpus**
+  (the system should say so rather than hallucinate).
+- Bootstrapped with a generator (RAGAS `TestsetGenerator` with personas —
+  "new employee", "HR admin"), then **manually reviewed and culled**; plus
+  hand-written terse real-user-style queries.
+
+### Metrics — two tiers
+
+1. **Retrieval metrics** (deterministic, no LLM, cheap — CI-able): run the
+   golden questions against the retrieval endpoint and compute
+   **Recall@5/10, MRR, nDCG@10** (`ranx` or `pytrec_eval`). This directly
+   answers "are the correct source documents found?" — the MVP success
+   criterion from the kickoff ("we actually get the documents that make
+   sense for that question").
+2. **Answer metrics** (LLM-as-judge, run on demand/nightly): **faithfulness**
+   (is every claim grounded in the retrieved sources?) and **answer
+   relevancy**, via **RAGAS** (Apache-2.0, vendor-neutral, any judge LLM —
+   can use the same Ollama server). Judge scores are calibrated against a
+   one-time human-labeled sample before being trusted for trend-tracking.
+
+MVP acceptance target (proposal, to be confirmed once baseline numbers
+exist): Recall@10 ≥ 0.8 on the golden set for answerable questions, and no
+hallucinated sources; answers for unanswerable questions must decline.
+
+## 8. Open questions / decisions still to be made
+
+Ordered by how early they block implementation. Each has a recommended
+default from the research phase.
+
+1. **Chunk storage model in Solr.** (a) chunks as sibling documents with
+   `parent_uid` + denormalized security fields, parent-collapse at query
+   time — flexible, works on Solr 9.x, plays well with Plone's per-object
+   reindexing; (b) nested child documents/block-join — poor fit (atomic
+   block reindexing conflicts with Plone; knn-through-block-join is Solr
+   10.x); (c) MVP-minimal: no chunks at all — one truncated-document vector
+   in the existing `content_vector` field, accepting blurry retrieval on
+   long documents. **Recommendation: (a)**; (c) is acceptable only as a
+   phase-1 stepping stone. *Blocks Phase 1.*
+2. **Pure vector vs. hybrid retrieval in the MVP.** Hybrid (client-side RRF)
+   is the industry default and the likely end state, but it doubles the
+   query path. **Recommendation: implement pure knn first, keep the query
+   layer factored so client-side RRF is a bounded add-on in the quality
+   phase, decided by golden-set numbers.** *Decided by Phase 5 data.*
+3. **Embedding model / multilinguality.** `nomic-embed-text` (English) vs
+   `nomic-embed-text-v2-moe` (multilingual incl. German, same 768 dims).
+   If German content is in MVP scope, v2-moe from the start avoids a full
+   reindex later; requires confirming it is available on the kitconcept
+   Ollama server. **Recommendation: confirm German requirements now; prefer
+   v2-moe if the server can host it.** *Blocks Phase 1 (index format).*
+4. **Embedding at indexing time: synchronous vs. queued.** Synchronous (in
+   the indexer/subscriber) is simple but adds an HTTP call per document to
+   every save and couples editing latency to the Ollama server. A queue
+   (async worker) is more robust but more moving parts. **Recommendation:
+   synchronous with a short timeout and skip-on-failure for the MVP; batch
+   endpoint for full reindexes. Revisit if editing latency hurts.**
+5. **Generation model choice.** Which general-purpose LLM on the kitconcept
+   Ollama server (quality vs. latency; answer language must follow the
+   question language). Needs a quick bake-off on the golden set. *Phase 3.*
+6. **Similarity function.** Schema says `dot_product`; nomic via `/api/embed`
+   returns normalized vectors, so it is equivalent to cosine. Keep
+   `dot_product` (no change) unless we switch to a model with unnormalized
+   outputs. *Effectively decided; recorded for the record.*
+7. **Demo corpus language and content** (see §7): synthetic fictional org
+   (which language(s)?) vs GitLab Handbook subset. **Recommendation:
+   synthetic, English first unless German is required for the first demo.**
+   *Blocks Phase 2.*
+8. **UX details of the modal**: trigger points (does it fully replace the
+   search bar?), mobile behavior, wording of the AI disclaimer, behavior
+   when the feature is disabled. Needs the short UX spec. *Blocks Phase 4.*
+9. **Chunk-level vs document-level context for the LLM prompt**: send parent
+   documents or the matched chunks (parent-document retrieval suggests:
+   retrieve by chunk, prompt with chunk + surrounding context, cite parent).
+   **Recommendation: prompt with matched chunks (+ title/URL), cite
+   parents.** *Phase 3.*
+
+## 9. References
+
+Research summaries behind the recommendations (full reports in the planning
+ticket):
+
+- Solr dense vector search: https://solr.apache.org/guide/solr/latest/query-guide/dense-vector-search.html
+- Solr native RRF (unreleased, 9.11/10.1): https://issues.apache.org/jira/browse/SOLR-17319
+- RRF (Cormack et al. 2009): https://dl.acm.org/doi/10.1145/1571941.1572114
+- BEIR benchmark (dense vs BM25 out-of-domain): https://github.com/beir-cellar/beir
+- nomic-embed-text (prefixes, /api/embed, num_ctx): https://ollama.com/library/nomic-embed-text · https://docs.ollama.com/capabilities/embeddings
+- nomic-embed-text-v2-moe (multilingual): https://ollama.com/library/nomic-embed-text-v2-moe
+- Chunking practice: https://www.firecrawl.dev/blog/best-chunking-strategies-rag · https://weaviate.io/blog/chunking-strategies-for-rag
+- RAGAS (metrics + testset generation): https://docs.ragas.io/
+- Retrieval metrics tooling: https://github.com/cvangysel/pytrec_eval · https://github.com/AmenRa/ranx
+- Golden-set / eval practice: https://hamel.dev/blog/posts/evals-faq/
+- CRAG question taxonomy: https://arxiv.org/abs/2406.04744
+- RAGBench (CC BY 4.0): https://huggingface.co/datasets/galileo-ai/ragbench
+- GitLab Handbook license: https://about.gitlab.com/blog/our-handbook-is-open-source-heres-why/
+- GermanQuAD: https://huggingface.co/datasets/deepset/germanquad
+- German law corpus: https://github.com/bundestag/gesetze

--- a/news/79.documentation
+++ b/news/79.documentation
@@ -1,0 +1,1 @@
+Add specification and implementation plan for the AI search (RAG) feature. @reebalazs


### PR DESCRIPTION
Planning documents for #79 — the single-turn RAG search MVP (natural-language question → summary answer + source documents).

- `SPECIFICATION-79.md`: goals, MVP scope, architecture (embedding via Ollama `/api/embed`, chunked indexing into the existing `content_vector` field, `{!knn}` retrieval with security pre-filters, LLM answer synthesis), configuration approach, demo site and evaluation methodology, and the open questions with recommended defaults.
- `IMPLEMENTATION-79.md`: phased task breakdown (Phases 1–4 = MVP, Phase 5 = data-driven quality pass), integration points in the current codebase, risks, and the tight MVP working order.

These are draft-for-discussion documents; the main open decisions that block implementation are the chunk storage model, the embedding model (English vs multilingual), and the demo corpus choice — all itemized in the spec §8.