### PR TITLE
Fix three RUF005 lint violations invisible to CI

### DIFF
--- a/backend/news/+navigation-ruff005.internal
+++ b/backend/news/+navigation-ruff005.internal
@@ -1,0 +1,1 @@
+Fix three RUF005 lint violations in the navigation tests that were invisible to CI (the shared lint workflow's `ruff check --diff` only reports violations with a safe autofix). @reebalazs

--- a/backend/tests/services/navigation/test_services_navigation.py
+++ b/backend/tests/services/navigation/test_services_navigation.py
@@ -40,7 +40,7 @@ class TestServicesNavigation(unittest.TestCase):
         settings = registry.forInterface(INavigationSchema, prefix="plone")
         displayed_types = settings.displayed_types
         if "Folder" not in displayed_types:
-            settings.displayed_types = tuple(list(displayed_types) + ["Folder"])
+            settings.displayed_types = (*displayed_types, "Folder")
 
         self.api_session = RelativeSession(self.portal_url, test=self)
         self.api_session.headers.update({"Accept": "application/json"})
@@ -110,7 +110,7 @@ class TestServicesNavigation(unittest.TestCase):
         registry = getUtility(IRegistry)
         settings = registry.forInterface(INavigationSchema, prefix="plone")
         displayed_types = settings.displayed_types
-        settings.displayed_types = tuple(list(displayed_types) + ["File"])
+        settings.displayed_types = (*displayed_types, "File")
         create(
             self.portal,
             "File",
@@ -221,7 +221,7 @@ class TestServicesNavigation(unittest.TestCase):
         registry = getUtility(IRegistry)
         settings = registry.forInterface(INavigationSchema, prefix="plone")
         displayed_types = settings.displayed_types
-        settings.displayed_types = tuple(list(displayed_types) + ["DXTestDocument"])
+        settings.displayed_types = (*displayed_types, "DXTestDocument")
 
         title = "Example Document"
         nav_title = "Fancy title"


### PR DESCRIPTION
Three pre-existing RUF005 violations (list concatenation) in the navigation tests never failed CI: the shared plone/meta backend-lint workflow runs `ruff check --diff`, which only reports violations that have a **safe** autofix — RUF005's fix is classified unsafe, so `--diff` produces no output and exits 0, while a plain `ruff check` reports them.

Fixed with behavior-identical tuple unpacking; navigation tests green, `ruff check` on the test tree clean.

Note for a possible follow-up (out of scope here): the `--diff` behavior means any unsafe-fix-only rule violation passes CI — a structural gap in the shared lint workflow, possibly worth raising on plone/meta.