### PR TITLE
Test Solr on ephemeral host ports - never touches a site Solr

### DIFF
--- a/backend/news/83.internal
+++ b/backend/news/83.internal
@@ -1,0 +1,1 @@
+The test Solr/Tika containers use ephemeral host ports: the tests never touch (nor get blocked by) a locally running site Solr on 8983, and a dev site and the test suite can run at the same time. @reebalazs

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from pytest_plone import fixtures_factory
 from requests import exceptions as exc
 
+import os
 import pytest
 import requests
 
@@ -77,6 +78,12 @@ def docker_compose_project_name() -> str:
 @pytest.fixture(scope="session")
 def docker_setup():
     """Return the Docker Compose commands to set up the stack."""
+    # Ephemeral host ports for the test containers: the tests must
+    # never coincide with a locally running site Solr on 8983 - with
+    # fixed ports they would either clobber its index or fail to bind.
+    # The actual port is read back via docker_services.port_for.
+    os.environ.setdefault("SOLR_ACCEPTANCE_PORT", "0")
+    os.environ.setdefault("TIKA_ACCEPTANCE_PORT", "0")
     # Stop the stack before starting a new one, only start the Solr service
     profile = "solr"
     return [f"--profile {profile} down -v", f"--profile {profile} up --build -d"]
@@ -91,10 +98,15 @@ def docker_compose_file(pytestconfig):
 
 
 @pytest.fixture(scope="session")
-def solr_service(docker_ip, docker_services):
+def solr_port(docker_services) -> int:
+    """The (ephemeral) host port of the test Solr container."""
+    return docker_services.port_for("solr-acceptance", 8983)
+
+
+@pytest.fixture(scope="session")
+def solr_service(docker_ip, docker_services, solr_port):
     """Ensure that Solr service is up and responsive."""
-    port = docker_services.port_for("solr-acceptance", 8983)
-    url = f"http://{docker_ip}:{port}/solr/plone/admin/ping?wt=xml"
+    url = f"http://{docker_ip}:{solr_port}/solr/plone/admin/ping?wt=xml"
     docker_services.wait_until_responsive(
         timeout=90.0, pause=0.1, check=lambda: is_responsive(url)
     )

--- a/backend/tests/services/conftest.py
+++ b/backend/tests/services/conftest.py
@@ -113,13 +113,20 @@ def registry_config() -> dict:
 
 
 @pytest.fixture(scope="class")
-def portal(app, solr_service, http_request, users, registry_config):
+def portal(app, solr_service, solr_port, http_request, users, registry_config):
     """Plone portal with additional users, and registry configuration set."""
     portal = app["plone"]
     setSite(portal)
     current_values = {}
     with api.env.adopt_roles(["Manager", "Member"]):
-        for key, value in registry_config.items():
+        # The test Solr runs on an ephemeral host port (never the fixed
+        # 8983 of a locally running site Solr) - point collective.solr
+        # at it. Applied outside registry_config so that module-level
+        # registry_config overrides cannot lose it.
+        for key, value in {
+            "collective.solr.port": solr_port,
+            **registry_config,
+        }.items():
             current_values[key] = api.portal.get_registry_record(key)
             api.portal.set_registry_record(key, value)
         maintenance = api.content.get_view("solr-maintenance", portal, http_request)

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -7,7 +7,9 @@ services:
     image: apache/tika:3.2.3.0-full
     profiles: ["acceptance", "dev", "solr"]
     ports:
-      - 9998:9998
+      # Host port for the container. Pytest sets this to 0 (ephemeral)
+      # so test runs never collide with a locally running stack.
+      - "${TIKA_ACCEPTANCE_PORT:-9998}:9998"
 
   solr-acceptance:
     build:
@@ -17,7 +19,10 @@ services:
     depends_on:
       - tika-acceptance
     ports:
-      - 8983:8983
+      # Host port for the container. Pytest sets this to 0 (ephemeral)
+      # so test runs never touch (or get blocked by) a locally running
+      # site Solr on 8983; manual/acceptance use keeps the fixed port.
+      - "${SOLR_ACCEPTANCE_PORT:-8983}:8983"
     command:
       - solr-precreate
       - plone

--- a/news/83.internal
+++ b/news/83.internal
@@ -1,0 +1,1 @@
+The test Solr/Tika containers use ephemeral host ports (docker-compose-dev.yml mappings are parameterized): the tests never touch a locally running site Solr on 8983, and a dev site and the test suite can run at the same time. @reebalazs


### PR DESCRIPTION
Fixes #83.

The test containers (solr-acceptance, tika-acceptance) bound the fixed host ports 8983/9998 — the same port a locally running site Solr uses — so the tests either clobbered its index (healed only by a full reindex) or could not start at all.

The compose mappings are now parameterized (`${SOLR_ACCEPTANCE_PORT:-8983}:8983`) and pytest sets them to `0`, so **every test session gets ephemeral host ports**; manual/acceptance use keeps the fixed defaults. The Plone test fixture points `collective.solr.port` at the dynamic port (applied outside `registry_config`, so module-level overrides cannot lose it).

**Verified**: with a site Solr running on 8983 holding a marker document, the suite ran on an ephemeral port (55001) and the marker survived untouched — dev site and test suite can now run at the same time.