### PR TITLE
Speed up the Solr test suite ~8.5x: 7:27 -> 0:53

### DIFF
--- a/backend/news/81.internal
+++ b/backend/news/81.internal
@@ -1,0 +1,1 @@
+The backend test suite runs ~8.5x faster (7:27 -> 0:53): the Plone test layers stay alive for the whole pytest session instead of being rebuilt per test class, and content creation plus the Solr query of a parametrized test class run once per class instead of once per assertion. @reebalazs

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -19,6 +19,45 @@ globals().update(
 )
 
 
+@pytest.fixture(scope="class")
+def functional_class_bracket(functional_class):
+    """A class-scoped test bracket on the functional layer.
+
+    Runs the layer's testSetUp/testTearDown once per test *class*
+    instead of once per test function, so expensive per-class fixtures
+    (content creation, a shared query) can be set up a single time and
+    shared by all tests of the class - the pattern the old
+    zope.testrunner layers provided. plone.testing layer resources are
+    stacked (LIFO), so per-function brackets can still nest inside if
+    a test also uses the function-scoped ``functional`` fixture.
+
+    Tests of a class using this bracket share one ZODB/Solr state:
+    suitable for the common read-only pattern (create content, run a
+    query, assert many times); not for tests that mutate content.
+    """
+    layer = functional_class
+    layer.testSetUp()
+    yield layer
+    layer.testTearDown()
+
+
+@pytest.fixture(scope="session", autouse=True)
+def keep_zope_layers(functional_session, integration_session):
+    """Keep the expensive Plone test layers alive for the whole session.
+
+    zope.pytestlayer only preserves layers across test classes for
+    zope.testrunner style tests (with a ``layer`` class attribute);
+    for pytest style tests its class-scoped layer fixture tears the
+    whole layer stack down after every test class, so the Plone site
+    got rebuilt many times per run - the main reason the suite became
+    much slower after the unittest to pytest migration. Depending on
+    the session-scoped layer fixtures marks the layers as
+    keep-for-whole-session: they are set up once and torn down at the
+    end of the session. Per-test isolation (testSetUp/testTearDown)
+    is unaffected.
+    """
+
+
 def is_responsive(url):
     """Helper fixture to check if Solr is up and running."""
     try:
@@ -51,7 +90,7 @@ def docker_compose_file(pytestconfig):
     return repo_root / "docker-compose-dev.yml"
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def solr_service(docker_ip, docker_services):
     """Ensure that Solr service is up and responsive."""
     port = docker_services.port_for("solr-acceptance", 8983)

--- a/backend/tests/services/conftest.py
+++ b/backend/tests/services/conftest.py
@@ -12,13 +12,13 @@ import pytest
 import transaction
 
 
-@pytest.fixture
+@pytest.fixture(scope="class")
 def users() -> list:
     """Additional users to be created."""
     return []
 
 
-@pytest.fixture
+@pytest.fixture(scope="class")
 def contents() -> list:
     """Content to be created."""
     return [
@@ -61,7 +61,7 @@ def all_path_string():
     return func
 
 
-@pytest.fixture
+@pytest.fixture(scope="class")
 def create_contents(contents):
     """Helper fixture to create initial content."""
 
@@ -96,23 +96,23 @@ def create_contents(contents):
     return func
 
 
-@pytest.fixture()
-def app(functional):
-    return functional["app"]
+@pytest.fixture(scope="class")
+def app(functional_class_bracket):
+    return functional_class_bracket["app"]
 
 
-@pytest.fixture()
-def http_request(functional):
-    return functional["request"]
+@pytest.fixture(scope="class")
+def http_request(functional_class_bracket):
+    return functional_class_bracket["request"]
 
 
-@pytest.fixture()
+@pytest.fixture(scope="class")
 def registry_config() -> dict:
     """Fixture with plone.app.registry settings."""
     return {"collective.solr.active": 1}
 
 
-@pytest.fixture()
+@pytest.fixture(scope="class")
 def portal(app, solr_service, http_request, users, registry_config):
     """Plone portal with additional users, and registry configuration set."""
     portal = app["plone"]
@@ -135,7 +135,7 @@ def portal(app, solr_service, http_request, users, registry_config):
     transaction.commit()
 
 
-@pytest.fixture()
+@pytest.fixture(scope="class")
 def portal_with_content(app, portal, create_contents):
     """Plone portal with initial content."""
     with api.env.adopt_roles(["Manager"]):
@@ -150,7 +150,7 @@ def portal_with_content(app, portal, create_contents):
     transaction.commit()
 
 
-@pytest.fixture()
+@pytest.fixture(scope="class")
 def maintenance(portal, http_request):
     """Return browser view for solr maintenance."""
     with api.env.adopt_roles(["Manager"]):
@@ -158,7 +158,7 @@ def maintenance(portal, http_request):
     return view
 
 
-@pytest.fixture()
+@pytest.fixture(scope="class")
 def request_factory(portal):
     """Fixture returning a session to call the API."""
 
@@ -171,13 +171,13 @@ def request_factory(portal):
     return factory
 
 
-@pytest.fixture()
+@pytest.fixture(scope="class")
 def anon_request(request_factory):
     """Anonymous API requests."""
     return request_factory()
 
 
-@pytest.fixture()
+@pytest.fixture(scope="class")
 def manager_request(request_factory):
     """Manager API requests."""
     request = request_factory()

--- a/backend/tests/services/content_filters/conftest.py
+++ b/backend/tests/services/content_filters/conftest.py
@@ -1,7 +1,7 @@
 import pytest
 
 
-@pytest.fixture
+@pytest.fixture(scope="class")
 def contents() -> list:
     return [
         {

--- a/backend/tests/services/content_filters/test_endpoint_contentfields.py
+++ b/backend/tests/services/content_filters/test_endpoint_contentfields.py
@@ -4,11 +4,11 @@ import pytest
 class TestEndpointContentFields:
     url: str = "@solr"
 
-    @pytest.fixture(autouse=True)
-    def _init(self, portal_with_content, manager_request):
-        self.portal = portal_with_content
-        response = manager_request.get(self.url)
-        self.data = response.json()
+    @pytest.fixture(autouse=True, scope="class")
+    def _init(self, request, portal_with_content, manager_request):
+        request.cls.portal = portal_with_content
+        response = manager_request.get(request.cls.url)
+        request.cls.data = response.json()
 
 
 class TestEndpointContentFieldsId(TestEndpointContentFields):

--- a/backend/tests/services/content_filters/test_endpoint_portaltype.py
+++ b/backend/tests/services/content_filters/test_endpoint_portaltype.py
@@ -2,11 +2,11 @@ import pytest
 
 
 class TestEndpointPortalType:
-    @pytest.fixture(autouse=True)
-    def _init(self, portal_with_content, manager_request):
-        self.portal = portal_with_content
-        response = manager_request.get(self.url)
-        self.data = response.json()
+    @pytest.fixture(autouse=True, scope="class")
+    def _init(self, request, portal_with_content, manager_request):
+        request.cls.portal = portal_with_content
+        response = manager_request.get(request.cls.url)
+        request.cls.data = response.json()
 
 
 class TestEndpointPortalTypeNotPassed(TestEndpointPortalType):

--- a/backend/tests/services/custom_config/test_endpoint_custom.py
+++ b/backend/tests/services/custom_config/test_endpoint_custom.py
@@ -37,7 +37,7 @@ solr_config = {
 }
 
 
-@pytest.fixture()
+@pytest.fixture(scope="class")
 def registry_config() -> dict:
     """Override registry configuration."""
     return {
@@ -47,11 +47,11 @@ def registry_config() -> dict:
 
 
 class TestEndpointCustom:
-    @pytest.fixture(autouse=True)
-    def _init(self, portal_with_content, manager_request):
-        self.portal = portal_with_content
-        response = manager_request.get(self.url)
-        self.data = response.json()
+    @pytest.fixture(autouse=True, scope="class")
+    def _init(self, request, portal_with_content, manager_request):
+        request.cls.portal = portal_with_content
+        response = manager_request.get(request.cls.url)
+        request.cls.data = response.json()
 
 
 class TestEndpointCustomBaseSearch(TestEndpointCustom):

--- a/backend/tests/services/custom_config/test_endpoint_first_tab.py
+++ b/backend/tests/services/custom_config/test_endpoint_first_tab.py
@@ -37,7 +37,7 @@ solr_config = {
 }
 
 
-@pytest.fixture()
+@pytest.fixture(scope="class")
 def registry_config() -> dict:
     """Override registry configuration."""
     return {
@@ -47,11 +47,11 @@ def registry_config() -> dict:
 
 
 class TestEndpointFirstTab:
-    @pytest.fixture(autouse=True)
-    def _init(self, portal_with_content, manager_request):
-        self.portal = portal_with_content
-        response = manager_request.get(self.url)
-        self.data = response.json()
+    @pytest.fixture(autouse=True, scope="class")
+    def _init(self, request, portal_with_content, manager_request):
+        request.cls.portal = portal_with_content
+        response = manager_request.get(request.cls.url)
+        request.cls.data = response.json()
 
 
 class TestEndpointFirstTabBaseSearch(TestEndpointFirstTab):

--- a/backend/tests/services/default_config/test_endpoint_default.py
+++ b/backend/tests/services/default_config/test_endpoint_default.py
@@ -2,11 +2,11 @@ import pytest
 
 
 class TestEndpointDefault:
-    @pytest.fixture(autouse=True)
-    def _init(self, portal_with_content, manager_request):
-        self.portal = portal_with_content
-        response = manager_request.get(self.url)
-        self.data = response.json()
+    @pytest.fixture(autouse=True, scope="class")
+    def _init(self, request, portal_with_content, manager_request):
+        request.cls.portal = portal_with_content
+        response = manager_request.get(request.cls.url)
+        request.cls.data = response.json()
 
 
 class TestEndpointDefaultBaseSearch(TestEndpointDefault):

--- a/backend/tests/services/encoding/conftest.py
+++ b/backend/tests/services/encoding/conftest.py
@@ -1,7 +1,7 @@
 import pytest
 
 
-@pytest.fixture
+@pytest.fixture(scope="class")
 def contents() -> list:
     return [
         {

--- a/backend/tests/services/encoding/test_endpoint_encoding.py
+++ b/backend/tests/services/encoding/test_endpoint_encoding.py
@@ -2,11 +2,11 @@ import pytest
 
 
 class TestEndpointEncoding:
-    @pytest.fixture(autouse=True)
-    def _init(self, portal_with_content, manager_request):
-        self.portal = portal_with_content
-        response = manager_request.get(self.url)
-        self.data = response.json()
+    @pytest.fixture(autouse=True, scope="class")
+    def _init(self, request, portal_with_content, manager_request):
+        request.cls.portal = portal_with_content
+        response = manager_request.get(request.cls.url)
+        request.cls.data = response.json()
 
 
 class TestEndpointEncodingColon(TestEndpointEncoding):

--- a/backend/tests/services/extra_conditions/conftest.py
+++ b/backend/tests/services/extra_conditions/conftest.py
@@ -1,7 +1,7 @@
 import pytest
 
 
-@pytest.fixture
+@pytest.fixture(scope="class")
 def contents() -> list:
     return [
         {

--- a/backend/tests/services/extra_conditions/test_extra_conditions.py
+++ b/backend/tests/services/extra_conditions/test_extra_conditions.py
@@ -52,7 +52,7 @@ solr_config = {
 }
 
 
-@pytest.fixture()
+@pytest.fixture(scope="class")
 def registry_config() -> dict:
     """Override registry configuration."""
     return {
@@ -62,11 +62,11 @@ def registry_config() -> dict:
 
 
 class TestEndpointCustom:
-    @pytest.fixture(autouse=True)
-    def _init(self, portal_with_content, manager_request):
-        self.portal = portal_with_content
-        response = manager_request.get(self.url)
-        self.data = response.json()
+    @pytest.fixture(autouse=True, scope="class")
+    def _init(self, request, portal_with_content, manager_request):
+        request.cls.portal = portal_with_content
+        response = manager_request.get(request.cls.url)
+        request.cls.data = response.json()
 
 
 class TestExtraConditionsInactive(TestEndpointCustom):

--- a/backend/tests/services/facet_conditions/conftest.py
+++ b/backend/tests/services/facet_conditions/conftest.py
@@ -1,7 +1,7 @@
 import pytest
 
 
-@pytest.fixture
+@pytest.fixture(scope="class")
 def contents() -> list:
     return [
         {

--- a/backend/tests/services/facet_conditions/test_facet_conditions.py
+++ b/backend/tests/services/facet_conditions/test_facet_conditions.py
@@ -50,7 +50,7 @@ solr_config = {
 }
 
 
-@pytest.fixture()
+@pytest.fixture(scope="class")
 def registry_config() -> dict:
     """Override registry configuration."""
     return {
@@ -60,11 +60,13 @@ def registry_config() -> dict:
 
 
 class TestEndpointCustom:
-    @pytest.fixture(autouse=True)
-    def _init(self, portal_with_content, manager_request):
-        self.portal = portal_with_content
-        response = manager_request.get(self.url)
-        self.data = response.json()
+    @pytest.fixture(autouse=True, scope="class")
+    def _init(self, request, portal_with_content, manager_request):
+        request.cls.portal = portal_with_content
+        # url can be an instance property (derived per class); evaluate
+        # it on a throwaway instance
+        response = manager_request.get(request.cls().url)
+        request.cls.data = response.json()
 
 
 class TestFacetConditionsInactive(TestEndpointCustom):

--- a/backend/tests/services/highlighting/conftest.py
+++ b/backend/tests/services/highlighting/conftest.py
@@ -1,7 +1,7 @@
 import pytest
 
 
-@pytest.fixture
+@pytest.fixture(scope="class")
 def contents() -> list:
     """Content to be created."""
     return [

--- a/backend/tests/services/highlighting/test_endpoint_highlighting.py
+++ b/backend/tests/services/highlighting/test_endpoint_highlighting.py
@@ -2,11 +2,11 @@ import pytest
 
 
 class TestEndpointDefault:
-    @pytest.fixture(autouse=True)
-    def _init(self, portal_with_content, manager_request):
-        self.portal = portal_with_content
-        response = manager_request.get(self.url)
-        self.data = response.json()
+    @pytest.fixture(autouse=True, scope="class")
+    def _init(self, request, portal_with_content, manager_request):
+        request.cls.portal = portal_with_content
+        response = manager_request.get(request.cls.url)
+        request.cls.data = response.json()
 
     def func(data: dict) -> list[str]:
         return [item["path_string"] for item in data["response"]["docs"]]

--- a/backend/tests/services/highlighting/test_endpoint_highlighting_alternate_field.py
+++ b/backend/tests/services/highlighting/test_endpoint_highlighting_alternate_field.py
@@ -47,7 +47,7 @@ solr_config = {
 }
 
 
-@pytest.fixture()
+@pytest.fixture(scope="class")
 def registry_config() -> dict:
     """Override registry configuration."""
     return {

--- a/backend/tests/services/language/conftest.py
+++ b/backend/tests/services/language/conftest.py
@@ -1,7 +1,7 @@
 import pytest
 
 
-@pytest.fixture
+@pytest.fixture(scope="class")
 def contents() -> list:
     return [
         {

--- a/backend/tests/services/language/test_endpoint_language.py
+++ b/backend/tests/services/language/test_endpoint_language.py
@@ -2,11 +2,11 @@ import pytest
 
 
 class TestEndpointLanguage:
-    @pytest.fixture(autouse=True)
-    def _init(self, portal_with_content, manager_request):
-        self.portal = portal_with_content
-        response = manager_request.get(self.url)
-        self.data = response.json()
+    @pytest.fixture(autouse=True, scope="class")
+    def _init(self, request, portal_with_content, manager_request):
+        request.cls.portal = portal_with_content
+        response = manager_request.get(request.cls.url)
+        request.cls.data = response.json()
 
 
 class TestEndpointLanguageEN(TestEndpointLanguage):

--- a/backend/tests/services/language/test_endpoint_local_multilingual.py
+++ b/backend/tests/services/language/test_endpoint_local_multilingual.py
@@ -2,11 +2,11 @@ import pytest
 
 
 class TestEndpointMultilingual:
-    @pytest.fixture(autouse=True)
-    def _init(self, portal_with_content, manager_request):
-        self.portal = portal_with_content
-        response = manager_request.get(self.url)
-        self.data = response.json()
+    @pytest.fixture(autouse=True, scope="class")
+    def _init(self, request, portal_with_content, manager_request):
+        request.cls.portal = portal_with_content
+        response = manager_request.get(request.cls.url)
+        request.cls.data = response.json()
 
 
 class TestEndpointMultilingualGlobal(TestEndpointMultilingual):

--- a/backend/tests/services/local_search/test_endpoint_local.py
+++ b/backend/tests/services/local_search/test_endpoint_local.py
@@ -1,7 +1,7 @@
 import pytest
 
 
-@pytest.fixture
+@pytest.fixture(scope="class")
 def contents() -> list:
     return [
         {
@@ -40,11 +40,11 @@ def contents() -> list:
 
 
 class TestEndpointLocalSearch:
-    @pytest.fixture(autouse=True)
-    def _init(self, portal_with_content, manager_request):
-        self.portal = portal_with_content
-        response = manager_request.get(self.url)
-        self.data = response.json()
+    @pytest.fixture(autouse=True, scope="class")
+    def _init(self, request, portal_with_content, manager_request):
+        request.cls.portal = portal_with_content
+        response = manager_request.get(request.cls.url)
+        request.cls.data = response.json()
 
 
 class TestEndpointLocalSearchGlobal(TestEndpointLocalSearch):

--- a/backend/tests/services/permission/conftest.py
+++ b/backend/tests/services/permission/conftest.py
@@ -4,7 +4,7 @@ from plone.app.testing import SITE_OWNER_PASSWORD
 import pytest
 
 
-@pytest.fixture
+@pytest.fixture(scope="class")
 def contents() -> list:
     return [
         {
@@ -45,12 +45,12 @@ def contents() -> list:
     ]
 
 
-@pytest.fixture
+@pytest.fixture(scope="class")
 def user_credentials() -> tuple:
     return "user2", "averylongpasswordbutnotthatlong"
 
 
-@pytest.fixture
+@pytest.fixture(scope="class")
 def users(user_credentials) -> list:
     return [
         {
@@ -115,7 +115,7 @@ solr_config = {
 }
 
 
-@pytest.fixture()
+@pytest.fixture(scope="class")
 def registry_config() -> dict:
     """Override registry configuration."""
     return {

--- a/backend/tests/services/permission/test_endpoint_permissions.py
+++ b/backend/tests/services/permission/test_endpoint_permissions.py
@@ -23,9 +23,9 @@ class TestEndpointPerms:
 
         return func
 
-    @pytest.fixture(autouse=True)
-    def _init(self, portal_with_content):
-        self.portal = portal_with_content
+    @pytest.fixture(autouse=True, scope="class")
+    def _init(self, request, portal_with_content):
+        request.cls.portal = portal_with_content
 
 
 class TestEndpointPermsAll(TestEndpointPerms):

--- a/backend/tests/services/prevent_injection/conftest.py
+++ b/backend/tests/services/prevent_injection/conftest.py
@@ -1,7 +1,7 @@
 import pytest
 
 
-@pytest.fixture
+@pytest.fixture(scope="class")
 def contents() -> list:
     return [
         {

--- a/backend/tests/services/prevent_injection/test_prevent_injection.py
+++ b/backend/tests/services/prevent_injection/test_prevent_injection.py
@@ -2,11 +2,11 @@ import pytest
 
 
 class TestPreventInjection:
-    @pytest.fixture(autouse=True)
-    def _init(self, portal_with_content, manager_request):
-        self.portal = portal_with_content
-        response = manager_request.get(self.url)
-        self.data = response.json()
+    @pytest.fixture(autouse=True, scope="class")
+    def _init(self, request, portal_with_content, manager_request):
+        request.cls.portal = portal_with_content
+        response = manager_request.get(request.cls.url)
+        request.cls.data = response.json()
 
 
 class TestInjectionOfUppercaseOperatorsIsAvoided(TestPreventInjection):

--- a/backend/tests/services/response/test_response.py
+++ b/backend/tests/services/response/test_response.py
@@ -37,7 +37,7 @@ solr_config = {
 }
 
 
-@pytest.fixture()
+@pytest.fixture(scope="class")
 def registry_config() -> dict:
     """Override registry configuration."""
     return {
@@ -47,11 +47,11 @@ def registry_config() -> dict:
 
 
 class TestResponseCustom:
-    @pytest.fixture(autouse=True)
-    def _init(self, portal_with_content, manager_request):
-        self.portal = portal_with_content
-        response = manager_request.get(self.url)
-        self.data = response.json()
+    @pytest.fixture(autouse=True, scope="class")
+    def _init(self, request, portal_with_content, manager_request):
+        request.cls.portal = portal_with_content
+        response = manager_request.get(request.cls.url)
+        request.cls.data = response.json()
 
 
 class TestResponseKeepFullSolrResponseDefault(TestResponseCustom):

--- a/backend/tests/services/roles_and_users/conftest.py
+++ b/backend/tests/services/roles_and_users/conftest.py
@@ -4,7 +4,7 @@ from plone.app.testing import SITE_OWNER_PASSWORD
 import pytest
 
 
-@pytest.fixture
+@pytest.fixture(scope="class")
 def contents() -> list:
     return [
         {
@@ -23,17 +23,17 @@ def contents() -> list:
     ]
 
 
-@pytest.fixture
+@pytest.fixture(scope="class")
 def user_credentials() -> tuple:
     return "user2", "averylongpasswordbutnotthatlong"
 
 
-@pytest.fixture
+@pytest.fixture(scope="class")
 def member_as_user1_credentials() -> tuple:
     return "member_as_user1", "averylongpasswordbutnotthatlong"
 
 
-@pytest.fixture
+@pytest.fixture(scope="class")
 def users(user_credentials, member_as_user1_credentials) -> list:
     return [
         {

--- a/backend/tests/services/roles_and_users/test_roles_and_users.py
+++ b/backend/tests/services/roles_and_users/test_roles_and_users.py
@@ -29,9 +29,9 @@ class TestEndpointRolesAndUsers:
 
         return func
 
-    @pytest.fixture(autouse=True)
-    def _init(self, portal_with_content):
-        self.portal = portal_with_content
+    @pytest.fixture(autouse=True, scope="class")
+    def _init(self, request, portal_with_content):
+        request.cls.portal = portal_with_content
 
 
 class TestEndpointRolesAndUsersNoPermission(TestEndpointRolesAndUsers):

--- a/backend/tests/services/spellcheck/test_spellcheck.py
+++ b/backend/tests/services/spellcheck/test_spellcheck.py
@@ -2,10 +2,10 @@ import pytest
 
 
 class TestSpellcheck:
-    @pytest.fixture(autouse=True)
-    def _init(self, portal_with_content, manager_request):
-        self.portal = portal_with_content
-        self.manager_request = manager_request
+    @pytest.fixture(autouse=True, scope="class")
+    def _init(self, request, portal_with_content, manager_request):
+        request.cls.portal = portal_with_content
+        request.cls.manager_request = manager_request
 
 
 class TestSpellcheckCollateWithResults(TestSpellcheck):

--- a/backend/tests/services/suggest/test_suggest.py
+++ b/backend/tests/services/suggest/test_suggest.py
@@ -5,11 +5,11 @@ import urllib.parse
 
 
 class TestSuggestDefault:
-    @pytest.fixture(autouse=True)
-    def _init(self, portal_with_content, manager_request):
-        self.portal = portal_with_content
-        response = manager_request.get(self.url)
-        self.data = response.json()
+    @pytest.fixture(autouse=True, scope="class")
+    def _init(self, request, portal_with_content, manager_request):
+        request.cls.portal = portal_with_content
+        response = manager_request.get(request.cls.url)
+        request.cls.data = response.json()
 
 
 @pytest.fixture

--- a/backend/tests/services/vocabularies/test_vocabularies.py
+++ b/backend/tests/services/vocabularies/test_vocabularies.py
@@ -68,17 +68,17 @@ solr_config_no_vocabs = {
 
 
 class TestVocabulariesEndpoint:
-    @pytest.fixture(autouse=True)
-    def _init(self, portal_with_content, manager_request):
-        self.portal = portal_with_content
-        response = manager_request.get(self.url)
-        self.data = response.json()
+    @pytest.fixture(autouse=True, scope="class")
+    def _init(self, request, portal_with_content, manager_request):
+        request.cls.portal = portal_with_content
+        response = manager_request.get(request.cls.url)
+        request.cls.data = response.json()
 
 
 class TestVocabulariesInResponse(TestVocabulariesEndpoint):
     url = "/@solr?q=chomsky"
 
-    @pytest.fixture()
+    @pytest.fixture(scope="class")
     def registry_config(self) -> dict:
         return {
             "collective.solr.active": 1,
@@ -102,7 +102,7 @@ class TestVocabulariesInResponse(TestVocabulariesEndpoint):
 class TestVocabulariesEmptyInResponse(TestVocabulariesEndpoint):
     url = "/@solr?q=chomsky"
 
-    @pytest.fixture()
+    @pytest.fixture(scope="class")
     def registry_config(self) -> dict:
         return {
             "collective.solr.active": 1,


### PR DESCRIPTION
Fixes #81.

The Solr-based test suite became much slower after the unittest → pytest migration. Two verified causes, two fixes — **`tests/services` goes from 7:27 to 0:53 (449 tests, green)**:

## 1. Keep the Plone test layers alive for the whole session (7:27 → 4:18)

zope.pytestlayer only preserves layers across test classes for zope.testrunner-style tests; for pytest-style tests its class-scoped layer fixture tore the whole layer stack down after **every test class**, rebuilding the Plone site many times per run (empirically: 8 layer setups in a two-directory run). An autouse session fixture depending on the generated `*_session` layer fixtures marks the layers keep-for-whole-session. Per-test isolation is unaffected.

## 2. Class-scoped content and query setup for the service tests (4:18 → 0:53)

With parametrized tests, a single Solr query followed by N assertions ran as N separate tests — each repeating the full setup (registry, index clear, content creation, commit/reindex) and the same query. The services fixture chain and the per-class `_init` fixtures move to class scope, on a new `functional_class_bracket` fixture that runs the layer's `testSetUp`/`testTearDown` once per test class (plone.testing layer resources stack LIFO, so per-function brackets still nest inside where used).

**Verified with `--setup-show`**: a parametrized class with 4 tests runs `portal_with_content` (content creation) and `_init` (the query) exactly **once** each — previously 4× each. Safety verified by AST scan: no test body mutates content or registry (all mutations live in fixtures), so sharing one ZODB/Solr state per class is sound.

Note: expect a tiny overlap with #85 on the `solr_service` fixture scope — resolves trivially whichever merges second.