### PR TITLE
RAG foundations and indexing: chunked content embedding into Solr

### DIFF
--- a/IMPLEMENTATION-79.md
+++ b/IMPLEMENTATION-79.md
@@ -30,42 +30,99 @@ is live. This is the riskiest layer, so it goes first.
 
 **Foundations (1.5d):**
 
-- [ ] **1.1 LLM client module** (`backend/src/kitconcept/solr/llm/`):
+- [x] **1.1 LLM client module** (`backend/src/kitconcept/solr/llm/`):
       thin HTTP client for `POST /api/embed` (batched, `num_ctx` set,
       task prefixes `search_document:` / `search_query:`, truncation
       detection) and `POST /api/chat` (used in Step 3). Explicit timeouts;
       typed errors; no third-party LLM framework dependency.
-- [ ] **1.2 Minimal configuration**: the "AI search" toggle as a registry
+- [x] **1.2 Minimal configuration**: the "AI search" toggle as a registry
       record on `IKitconceptSolrSettings`
       (`backend/src/kitconcept/solr/interfaces.py` +
       `profiles/default/registry/`); endpoint URL + token as env vars wired
       through `docker-compose.yml` (pattern: `COLLECTIVE_SOLR_HOST`). Model
       names, topK, chunk parameters, prompt template: code defaults.
-- [ ] **1.3 Schema additions** for chunk sibling documents in
+- [x] **1.3 Schema additions** for chunk sibling documents in
       `solr/etc/conf/schema.xml` (chunk fields: `parent_uid`, denormalized
       `Title`, `path`, `allowedRolesAndUsers`, `Language`;
       `content_vector` populated on chunks).
 
 **Indexing (3d):**
 
-- [ ] **1.4 Chunking**: split extracted block text (reusing the traversal in
+- [x] **1.4 Chunking**: split extracted block text (reusing the traversal in
       `backend/src/kitconcept/solr/indexers/text.py`) into ~400-token
       structure-aware chunks with 10–15% overlap, merging tiny fragments.
       One kind of chunking (per the kick-off clarification); design kept
       compatible with the second kind.
-- [ ] **1.5 Index-time embedding**: hook after document assembly for
+- [x] **1.5 Index-time embedding**: hook after document assembly for
       `collective.solr` so each indexed object also writes its chunk
       documents with vectors — synchronous, short timeout,
       **skip-on-failure** (a save must never fail on embedding errors).
       Delete/unindex removes chunks. Record the embedding model name for
       reindex detection.
-- [ ] **1.6 Full-reindex support**: `solr-activate-and-reindex` populates
+- [x] **1.6 Full-reindex support**: `solr-activate-and-reindex` populates
       vectors using batched `/api/embed` calls.
-- [ ] Minimal inline test coverage with the PRs (repo CI standards); the
+- [x] Minimal inline test coverage with the PRs (repo CI standards); the
       full test pass is post-MVP (Step P1).
 
 Demo at end of step: indexed site content visible in Solr with chunk
 documents and populated vectors.
+
+### Implementation notes — Step 1 (design decisions made on the way)
+
+- **Hook: own indexing queue processor, not `ISolrAddHandler` adders.**
+  collective.solr queries its add handlers as *named* adapters by
+  portal type, so a single adapter cannot intercept all types. Instead,
+  `RagIndexProcessor` is registered as an `IIndexQueueProcessor`
+  utility (`componentregistry.xml`) — Plone's indexing queue dispatches
+  to every such utility, next to collective.solr's own processor, and
+  the RAG processor shares the same Solr connection. The module path
+  became `kitconcept/solr/rag/` (not `llm/` as sketched above): it
+  holds config, client, chunker, extraction, processor and reindex.
+- **Chunks are invisible to keyword search by construction.**
+  `chunk_text`/`parent_title` are stored-only (not indexed); chunks
+  carry none of the fields the `@solr` main query matches on. A
+  defensive `-is_rag_chunk:true` filter query was added to `@solr`
+  anyway.
+- **Chunk lifecycle**: chunk UIDs are `<parent UID>#rag-<n>`; a text
+  rebuild is delete-by-query + re-add (the chunk count may shrink).
+  A `MAX_CHUNKS_PER_DOCUMENT = 100` safety cap guards against
+  pathological documents (~40k tokens covered per document).
+- **Workflow transitions don't re-embed.** An attribute-limited
+  reindex that touches only metadata (`allowedRolesAndUsers`,
+  `Language`, path) updates the denormalized chunk fields in place via
+  Solr atomic updates; only text-affecting attributes trigger
+  re-chunking/re-embedding.
+- **Failure policy**: embedding errors log a warning and *keep* the
+  previously indexed chunks (slightly stale beats absent); the content
+  save itself never fails. Chunk cleanup on delete is gated on the
+  registry toggle only, so it works while the endpoint is unconfigured.
+- **Token sizing is heuristic** (4 chars/token, no tokenizer
+  dependency): chunk target 1600 chars ≈ 400 tokens under the model's
+  512-token limit; the client warns when an input still estimates over
+  the limit.
+- **Full reindex needs its own pass**: collective.solr's
+  `@@solr-maintenance` talks to Solr directly and bypasses queue
+  processors, so `reindex_helpers.reindex` now calls `reindex_rag`
+  afterwards (no-op when the feature is off).
+- **MVP text coverage**: title + description + Volto blocks. Binary
+  content (File/Image) is extracted by Tika *inside* Solr — the text
+  never passes through Plone, so it cannot be chunked/embedded here.
+  Post-MVP follow-up.
+- **Env overrides** `KITCONCEPT_SOLR_LLM_EMBED_MODEL`/`_CHAT_MODEL`
+  exist besides the code defaults, to ease testing against different
+  servers.
+- **Verified end to end against real Solr + the kitconcept LLM server**
+  (`tests/rag/test_e2e_live.py`, runs only when the LLM env vars are
+  set): indexing a document creates chunk documents with real vectors
+  through collective.solr's XML `update="set"` path; a `{!knn}` query
+  with the embedded question retrieves the right chunk; deletion
+  removes the chunks. Note: knn queries must be POSTed to Solr — the
+  768-float vector exceeds GET URL limits.
+- **kitconcept Genie (Open WebUI) endpoint constraints**: the server's
+  API key allowlist permits exactly `/ollama/api/embed` and
+  `/api/chat/completions`, so the client uses those as path defaults
+  (env-overridable for plain Ollama), chat speaks the OpenAI format,
+  and the embed model name needs its explicit `:latest` tag.
 
 ## Step 2 — Test corpus (0.5d)
 

--- a/Makefile
+++ b/Makefile
@@ -231,6 +231,14 @@ solr-activate-and-reindex: ## Activate solr and reindex content
 solr-activate-and-reindex-clear: ## Activate solr and reindex content with clear
 	$(MAKE) -C "./backend/" solr-activate-and-reindex-clear
 
+.PHONY: solr-activate-and-reindex-with-rag
+solr-activate-and-reindex-with-rag: ## Activate solr and RAG (AI search) and reindex content
+	$(MAKE) -C "./backend/" solr-activate-and-reindex-with-rag
+
+.PHONY: solr-activate-and-reindex-with-rag-clear
+solr-activate-and-reindex-with-rag-clear: ## Activate solr and RAG (AI search) and reindex content with clear
+	$(MAKE) -C "./backend/" solr-activate-and-reindex-with-rag-clear
+
 ###########################################
 # Acceptance
 ###########################################

--- a/SPECIFICATION-79.md
+++ b/SPECIFICATION-79.md
@@ -300,6 +300,7 @@ All major open questions from the draft phase have been decided (team review
 | 7 | Demo corpus | Translated German template content + ~20 hand-written questions; English first |
 | 8 | Search UX | External (kitconcept.intranet search modal project); "AI search" toggle |
 | 9 | Chunk vs. document context for the prompt | Prompt with matched chunks (+ parent title/URL), cite parents |
+| 10 | Failure policy: hard error vs. graceful degradation | **Graceful degradation, applied consistently** (2026-07-13): toggle on without credentials = the feature silently reports unavailable (no error); AI service down = users fall back to the classic search instead of a hard error. The effective state is exposed to the client as `kitconcept.solr.rag_available` on the @site endpoint (registry toggle AND credentials), so the UI renders the right thing from the first paint. Recorded as revisitable: if operational practice shows silent degradation hides real misconfigurations, we can move toward hard errors. |
 
 Remaining open point:
 

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -102,6 +102,14 @@ solr-activate-and-reindex: $(VENV_FOLDER) instance/etc/zope.ini ## Activate solr
 solr-activate-and-reindex-clear: $(VENV_FOLDER) instance/etc/zope.ini ## Activate solr and reindex content with clear
 	@PYTHONWARNINGS=ignore $(BIN_FOLDER)/zconsole run instance/etc/zope.conf ./scripts/solr_activate_and_reindex.py --clear
 
+.PHONY: solr-activate-and-reindex-with-rag
+solr-activate-and-reindex-with-rag: $(VENV_FOLDER) instance/etc/zope.ini ## Activate solr and RAG (AI search) and reindex content
+	@PYTHONWARNINGS=ignore $(BIN_FOLDER)/zconsole run instance/etc/zope.conf ./scripts/solr_activate_and_reindex.py --rag-enable
+
+.PHONY: solr-activate-and-reindex-with-rag-clear
+solr-activate-and-reindex-with-rag-clear: $(VENV_FOLDER) instance/etc/zope.ini ## Activate solr and RAG (AI search) and reindex content with clear
+	@PYTHONWARNINGS=ignore $(BIN_FOLDER)/zconsole run instance/etc/zope.conf ./scripts/solr_activate_and_reindex.py --rag-enable --clear
+
 # Example Content
 .PHONY: update-example-content
 update-example-content: $(VENV_FOLDER) ## Export example content inside package

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
     "plone.volto",
     "plone.app.multilingual",
     "collective.solr>=9.4.0",
+    "requests",
 ]
 
 [project.optional-dependencies]
@@ -166,7 +167,8 @@ order-by-type = false
 preview = true
 
 [tool.ruff.lint.per-file-ignores]
-"tests/*" = ["E501", "RUF001", "S101"]
+# S105/S106: test fixtures legitimately contain fake tokens
+"tests/*" = ["E501", "RUF001", "S101", "S105", "S106"]
 
 [tool.check-manifest]
 ignore = [

--- a/backend/scripts/solr_activate_and_reindex.py
+++ b/backend/scripts/solr_activate_and_reindex.py
@@ -14,7 +14,16 @@ if __name__ == "__main__":
     portal = app.unrestrictedTraverse(site_id)
     setSite(portal)
 
-    activate_and_reindex(portal, clear="--clear" in sys.argv)
+    # --rag-enable / --rag-disable switch the AI search registry toggle
+    # (before reindexing, so enabling also builds the RAG chunks);
+    # without either flag the toggle is left unchanged.
+    rag = None
+    if "--rag-enable" in sys.argv:
+        rag = True
+    elif "--rag-disable" in sys.argv:
+        rag = False
+
+    activate_and_reindex(portal, clear="--clear" in sys.argv, rag=rag)
 
     transaction.commit()
     app._p_jar.sync()

--- a/backend/src/kitconcept/solr/interfaces.py
+++ b/backend/src/kitconcept/solr/interfaces.py
@@ -2,6 +2,7 @@
 
 from kitconcept.solr import _
 from plone.schema import JSONField
+from zope import schema
 from zope.interface import Interface
 from zope.publisher.interfaces.browser import IDefaultBrowserLayer
 
@@ -87,4 +88,19 @@ class IKitconceptSolrSettings(Interface):
         schema=CONFIG_SCHEMA,
         default=DEFAULT_CONFIG,
         missing_value={"fieldList": [], "searchTabs": []},
+    )
+
+    rag_enabled = schema.Bool(
+        title=_("label_rag_enabled", default="AI search enabled"),
+        description=_(
+            "help_rag_enabled",
+            default=(
+                "Turn the RAG based AI search on or off. The feature also"
+                " requires the LLM endpoint to be configured through the"
+                " KITCONCEPT_SOLR_LLM_URL (and optionally"
+                " KITCONCEPT_SOLR_LLM_TOKEN) environment variables."
+            ),
+        ),
+        required=False,
+        default=False,
     )

--- a/backend/src/kitconcept/solr/profiles/default/componentregistry.xml
+++ b/backend/src/kitconcept/solr/profiles/default/componentregistry.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<componentregistry>
+  <utilities>
+    <!-- Indexing queue processor maintaining the RAG chunk documents.
+    Registered for the base IIndexQueueProcessor interface so the
+    Plone indexing queue dispatches to it next to collective.solr's
+    own processor. -->
+    <utility factory="kitconcept.solr.rag.processor.RagIndexProcessor"
+             interface="Products.CMFCore.interfaces.IIndexQueueProcessor"
+             name="kitconcept.solr.rag"
+    />
+  </utilities>
+</componentregistry>

--- a/backend/src/kitconcept/solr/profiles/default/metadata.xml
+++ b/backend/src/kitconcept/solr/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <metadata>
-  <version>1003</version>
+  <version>1004</version>
   <dependencies>
     <dependency>profile-collective.solr:default</dependency>
   </dependencies>

--- a/backend/src/kitconcept/solr/profiles/uninstall/componentregistry.xml
+++ b/backend/src/kitconcept/solr/profiles/uninstall/componentregistry.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<componentregistry>
+  <utilities>
+    <utility interface="Products.CMFCore.interfaces.IIndexQueueProcessor"
+             name="kitconcept.solr.rag"
+             remove="true"
+    />
+  </utilities>
+</componentregistry>

--- a/backend/src/kitconcept/solr/rag/__init__.py
+++ b/backend/src/kitconcept/solr/rag/__init__.py
@@ -1,0 +1,4 @@
+"""RAG (Retrieval-Augmented Generation) support for kitconcept.solr.
+
+See SPECIFICATION-79.md and IMPLEMENTATION-79.md in the repository root.
+"""

--- a/backend/src/kitconcept/solr/rag/chunker.py
+++ b/backend/src/kitconcept/solr/rag/chunker.py
@@ -1,0 +1,110 @@
+"""Structure-aware chunking of content text for embedding.
+
+Long documents embedded as a single vector become "blurry", and the
+embedding model additionally truncates its input at 512 tokens, so the
+extracted text is split into chunks of ~400 tokens (SPECIFICATION-79.md
+§3). Sizes are estimated with a chars-per-token heuristic — we have no
+access to the model's tokenizer, which is also why the chunk target
+leaves headroom below the model limit.
+
+The chunker is structure-aware in the sense that it packs whole
+segments (Volto blocks, paragraphs) and only splits inside a segment
+when the segment alone exceeds the chunk size — then preferably at
+sentence boundaries. Consecutive chunks overlap by a tail of the
+previous chunk so that statements on a chunk border stay retrievable.
+"""
+
+from kitconcept.solr.rag.config import CHUNK_MIN_CHARS
+from kitconcept.solr.rag.config import CHUNK_OVERLAP_CHARS
+from kitconcept.solr.rag.config import CHUNK_TARGET_CHARS
+
+import re
+
+
+SENTENCE_END = re.compile(r"(?<=[.!?])\s+")
+WHITESPACE = re.compile(r"\s+")
+
+
+def _normalize(text: str) -> str:
+    return WHITESPACE.sub(" ", text).strip()
+
+
+def split_long_text(text: str, limit: int) -> list[str]:
+    """Split a text into pieces of at most ``limit`` characters.
+
+    Prefers sentence boundaries; falls back to word boundaries, and to
+    a hard cut only for pathological unbroken runs.
+    """
+    if len(text) <= limit:
+        return [text]
+    pieces: list[str] = []
+    current = ""
+    for sentence in SENTENCE_END.split(text):
+        while len(sentence) > limit:
+            # Overlong sentence: cut at the last word boundary before
+            # the limit, or hard-cut when there is none.
+            cut = sentence.rfind(" ", 0, limit + 1)
+            if cut <= 0:
+                cut = limit
+            head, sentence = sentence[:cut].strip(), sentence[cut:].strip()
+            if current:
+                pieces.append(current)
+                current = ""
+            if head:
+                pieces.append(head)
+        candidate = f"{current} {sentence}".strip() if current else sentence
+        if len(candidate) > limit and current:
+            pieces.append(current)
+            current = sentence
+        else:
+            current = candidate
+    if current:
+        pieces.append(current)
+    return pieces
+
+
+def _overlap_tail(chunk: str) -> str:
+    """The tail of a chunk carried over into the next one."""
+    if len(chunk) <= CHUNK_OVERLAP_CHARS:
+        return chunk
+    tail = chunk[-CHUNK_OVERLAP_CHARS:]
+    # Start the overlap at a word boundary.
+    cut = tail.find(" ")
+    if cut >= 0:
+        tail = tail[cut + 1 :]
+    return tail
+
+
+def chunk_segments(segments: list[str]) -> list[str]:
+    """Pack text segments into overlapping chunks of the target size.
+
+    :param segments: Texts in document order (e.g. one per Volto
+        block). Segment boundaries are respected: a segment is only
+        split when it alone exceeds the chunk size.
+    :returns: Chunk texts in document order.
+    """
+    pieces: list[str] = []
+    for segment in segments:
+        segment = _normalize(segment)
+        if not segment:
+            continue
+        pieces.extend(split_long_text(segment, CHUNK_TARGET_CHARS))
+
+    chunks: list[str] = []
+    current = ""
+    for piece in pieces:
+        candidate = f"{current} {piece}".strip() if current else piece
+        if len(candidate) > CHUNK_TARGET_CHARS and current:
+            chunks.append(current)
+            current = f"{_overlap_tail(current)} {piece}".strip()
+        else:
+            current = candidate
+    if current:
+        # Merge a tiny trailing rest into the previous chunk instead of
+        # emitting a low-content chunk of its own.
+        if chunks and len(current) < CHUNK_MIN_CHARS:
+            merged = f"{chunks[-1]} {current}".strip()
+            chunks[-1] = merged
+        else:
+            chunks.append(current)
+    return chunks

--- a/backend/src/kitconcept/solr/rag/client.py
+++ b/backend/src/kitconcept/solr/rag/client.py
@@ -1,0 +1,149 @@
+"""HTTP client for the LLM server.
+
+Two endpoints are used (SPECIFICATION-79.md §3), with paths matching
+the kitconcept LLM server (Open WebUI in front of Ollama) whose API
+key allowlist permits exactly these two:
+
+- embeddings: Ollama-compatible ``POST <root>/ollama/api/embed`` —
+  batched, returns L2-normalized vectors. The nomic models require
+  task prefixes: content is embedded as ``search_document: ...`` and
+  queries as ``search_query: ...``; skipping them measurably degrades
+  retrieval.
+- chat: OpenAI-compatible ``POST <root>/api/chat/completions`` —
+  answer generation (used by the query pipeline).
+
+Both paths are configurable (see ``config``), e.g. for a plain Ollama
+server during local development.
+
+Embeddings are computed here on the Plone side rather than via Solr's
+LLM module, because that module does not support Ollama as a provider
+and cannot add the task prefixes.
+
+The client is deliberately a thin ``requests`` wrapper: explicit
+timeouts, typed errors, no third-party LLM framework dependency.
+"""
+
+from kitconcept.solr.rag.config import EMBED_BATCH_SIZE
+from kitconcept.solr.rag.config import EMBED_TOKEN_LIMIT
+from kitconcept.solr.rag.config import estimate_tokens
+from kitconcept.solr.rag.config import RagConfig
+
+import logging
+import requests
+
+
+logger = logging.getLogger("kitconcept.solr.rag")
+
+SEARCH_DOCUMENT_PREFIX = "search_document: "
+SEARCH_QUERY_PREFIX = "search_query: "
+
+
+class LLMClientError(Exception):
+    """Base error talking to the LLM server."""
+
+
+class LLMTimeout(LLMClientError):
+    """The LLM server did not answer within the timeout."""
+
+
+class LLMResponseError(LLMClientError):
+    """The LLM server answered, but not with what we expected."""
+
+
+class LLMClient:
+    """Client for the embedding and generation endpoints."""
+
+    def __init__(self, config: RagConfig):
+        self.config = config
+
+    def _post(self, path: str, payload: dict, timeout: float) -> dict:
+        url = f"{self.config.base_url}{path}"
+        headers = {}
+        if self.config.token:
+            headers["Authorization"] = f"Bearer {self.config.token}"
+        try:
+            response = requests.post(
+                url, json=payload, headers=headers, timeout=timeout
+            )
+        except requests.Timeout as e:
+            raise LLMTimeout(f"timeout after {timeout}s calling {path}") from e
+        except requests.RequestException as e:
+            raise LLMClientError(f"error calling {path}: {e}") from e
+        if response.status_code != 200:
+            raise LLMResponseError(
+                f"{path} returned {response.status_code}: {response.text[:200]}"
+            )
+        try:
+            return response.json()
+        except ValueError as e:
+            raise LLMResponseError(f"{path} returned invalid JSON") from e
+
+    def _embed_batch(self, texts: list[str]) -> list[list[float]]:
+        payload = {
+            "model": self.config.embed_model,
+            "input": texts,
+        }
+        result = self._post(self.config.embed_path, payload, self.config.embed_timeout)
+        embeddings = result.get("embeddings")
+        if not isinstance(embeddings, list) or len(embeddings) != len(texts):
+            raise LLMResponseError(
+                "unexpected embed response: "
+                f"{len(embeddings) if isinstance(embeddings, list) else 'no'} "
+                f"embeddings for {len(texts)} inputs"
+            )
+        return embeddings
+
+    def _embed(self, texts: list[str], prefix: str) -> list[list[float]]:
+        prefixed = [f"{prefix}{text}" for text in texts]
+        for text in prefixed:
+            tokens = estimate_tokens(text)
+            if tokens > EMBED_TOKEN_LIMIT:
+                # The model silently truncates beyond its sequence
+                # limit; the chunker should prevent this, so it is
+                # worth a warning when it happens anyway.
+                logger.warning(
+                    "embedding input of ~%d tokens exceeds the %d token "
+                    "limit of %s and will be truncated: %.80r...",
+                    tokens,
+                    EMBED_TOKEN_LIMIT,
+                    self.config.embed_model,
+                    text,
+                )
+        embeddings: list[list[float]] = []
+        for start in range(0, len(prefixed), EMBED_BATCH_SIZE):
+            batch = prefixed[start : start + EMBED_BATCH_SIZE]
+            embeddings.extend(self._embed_batch(batch))
+        return embeddings
+
+    def embed_documents(self, texts: list[str]) -> list[list[float]]:
+        """Embed content chunks for indexing."""
+        return self._embed(texts, SEARCH_DOCUMENT_PREFIX)
+
+    def embed_query(self, text: str) -> list[float]:
+        """Embed a user question for retrieval."""
+        return self._embed([text], SEARCH_QUERY_PREFIX)[0]
+
+    def chat(self, prompt: str, system: str | None = None) -> str:
+        """Generate an answer with the general-purpose model.
+
+        OpenAI-compatible chat completions request, non-streaming;
+        used by the query pipeline (implementation ticket for the
+        retrieval endpoint + answer generation).
+        """
+        messages = []
+        if system:
+            messages.append({"role": "system", "content": system})
+        messages.append({"role": "user", "content": prompt})
+        payload = {
+            "model": self.config.chat_model,
+            "messages": messages,
+            "stream": False,
+        }
+        result = self._post(self.config.chat_path, payload, self.config.chat_timeout)
+        try:
+            content = result["choices"][0]["message"]["content"]
+        except (KeyError, IndexError, TypeError) as e:
+            raise LLMResponseError("unexpected chat response shape") from e
+        if not isinstance(content, str):
+            raise LLMResponseError("unexpected chat content type")
+        return content

--- a/backend/src/kitconcept/solr/rag/config.py
+++ b/backend/src/kitconcept/solr/rag/config.py
@@ -1,0 +1,123 @@
+"""Configuration for the RAG feature.
+
+MVP configuration is deliberately minimal (SPECIFICATION-79.md §5):
+
+- The "AI search" feature toggle lives in the Plone registry
+  (``kitconcept.solr.rag_enabled``), so an admin can turn the feature
+  on or off.
+- The LLM endpoint URL and credentials come from environment variables,
+  following the ``COLLECTIVE_SOLR_HOST`` pattern. Credentials must not
+  live in the registry, because registry content ends up in exported
+  site configuration.
+- Everything else (model names, chunking parameters, timeouts) is a
+  code default here. Environment overrides exist for the model names to
+  ease testing against different servers; promoting them to registry
+  records is a post-MVP task.
+"""
+
+from dataclasses import dataclass
+from plone.registry.interfaces import IRegistry
+from zope.component import queryUtility
+
+import os
+
+
+# Fixed models for the MVP (SPECIFICATION-79.md §8, decisions 3 and 5).
+# The explicit :latest tag is required: the kitconcept server does not
+# resolve the bare model name.
+DEFAULT_EMBED_MODEL = "nomic-embed-text-v2-moe:latest"
+DEFAULT_CHAT_MODEL = "qwen3:14b"
+
+# nomic-embed-text-v2-moe truncates input at 512 tokens. Chunks target
+# ~400 tokens to leave headroom for the task prefix and tokenizer
+# variance (SPECIFICATION-79.md §3). We have no access to the model's
+# tokenizer, so sizes are estimated with a chars-per-token heuristic.
+EMBED_TOKEN_LIMIT = 512
+CHUNK_TARGET_TOKENS = 400
+CHARS_PER_TOKEN = 4
+CHUNK_TARGET_CHARS = CHUNK_TARGET_TOKENS * CHARS_PER_TOKEN
+# 10-15% overlap between consecutive chunks.
+CHUNK_OVERLAP_CHARS = CHUNK_TARGET_CHARS // 8
+# Fragments smaller than this are merged with their neighbor.
+CHUNK_MIN_CHARS = 128
+
+# Timeouts (seconds). Indexing must never hang a worker for long; the
+# chat timeout is generous because answer generation takes a while.
+EMBED_TIMEOUT = 30.0
+CHAT_TIMEOUT = 120.0
+
+# Number of texts sent to /api/embed in one request.
+EMBED_BATCH_SIZE = 32
+
+REGISTRY_ENABLED_KEY = "kitconcept.solr.rag_enabled"
+
+# Endpoint paths, relative to the server root URL. The defaults match
+# the kitconcept LLM server (Open WebUI in front of Ollama), whose API
+# key allowlist permits exactly these two endpoints: embeddings via the
+# Ollama-compatible proxy, chat via the native OpenAI-compatible
+# endpoint. For a plain Ollama server, override with
+# EMBED_PATH=/api/embed and CHAT_PATH=/v1/chat/completions.
+DEFAULT_EMBED_PATH = "/ollama/api/embed"
+DEFAULT_CHAT_PATH = "/api/chat/completions"
+
+ENV_URL = "KITCONCEPT_SOLR_LLM_URL"
+ENV_TOKEN = "KITCONCEPT_SOLR_LLM_TOKEN"  # noqa: S105 - env var name, not a secret
+ENV_EMBED_MODEL = "KITCONCEPT_SOLR_LLM_EMBED_MODEL"
+ENV_CHAT_MODEL = "KITCONCEPT_SOLR_LLM_CHAT_MODEL"
+ENV_EMBED_PATH = "KITCONCEPT_SOLR_LLM_EMBED_PATH"
+ENV_CHAT_PATH = "KITCONCEPT_SOLR_LLM_CHAT_PATH"
+
+
+@dataclass(frozen=True)
+class RagConfig:
+    """Resolved configuration for the RAG feature."""
+
+    base_url: str
+    token: str | None
+    embed_model: str
+    chat_model: str
+    embed_path: str = DEFAULT_EMBED_PATH
+    chat_path: str = DEFAULT_CHAT_PATH
+    embed_timeout: float = EMBED_TIMEOUT
+    chat_timeout: float = CHAT_TIMEOUT
+
+
+def rag_enabled() -> bool:
+    """Is the "AI search" registry toggle on?
+
+    Defends against a missing record (e.g. site not upgraded yet).
+    """
+    registry = queryUtility(IRegistry)
+    if registry is None:
+        return False
+    try:
+        return bool(registry[REGISTRY_ENABLED_KEY])
+    except KeyError:
+        return False
+
+
+def get_rag_config() -> RagConfig | None:
+    """Return the resolved configuration, or None when the feature is off.
+
+    The feature counts as enabled when the registry toggle is on *and*
+    the endpoint URL environment variable is present.
+    """
+    if not rag_enabled():
+        return None
+    base_url = os.environ.get(ENV_URL, "").strip().rstrip("/")
+    if not base_url:
+        return None
+    token = os.environ.get(ENV_TOKEN, "").strip() or None
+    return RagConfig(
+        base_url=base_url,
+        token=token,
+        embed_model=os.environ.get(ENV_EMBED_MODEL, "").strip() or DEFAULT_EMBED_MODEL,
+        chat_model=os.environ.get(ENV_CHAT_MODEL, "").strip() or DEFAULT_CHAT_MODEL,
+        embed_path=os.environ.get(ENV_EMBED_PATH, "").strip() or DEFAULT_EMBED_PATH,
+        chat_path=os.environ.get(ENV_CHAT_PATH, "").strip() or DEFAULT_CHAT_PATH,
+    )
+
+
+def estimate_tokens(text: str) -> int:
+    """Heuristic token count (no tokenizer dependency)."""
+    return -(-len(text) // CHARS_PER_TOKEN)

--- a/backend/src/kitconcept/solr/rag/extraction.py
+++ b/backend/src/kitconcept/solr/rag/extraction.py
@@ -1,0 +1,37 @@
+"""Extraction of chunkable text segments from content objects.
+
+Reuses the block text extraction of the ``body_text_blocks`` indexer
+(``kitconcept.solr.indexers.text``) but keeps the per-block texts as
+separate segments, in layout order, so the chunker can respect the
+structural boundaries.
+
+MVP scope note: RAG covers block-based content plus title/description.
+The body text of binary content (File, Image) is extracted by Tika
+inside Solr and never passes through Plone, so it cannot be chunked
+and embedded here; supporting it is a post-MVP follow-up.
+"""
+
+from kitconcept.solr.indexers.text import extract_text
+from plone.restapi.behaviors import IBlocks
+from zope.globalrequest import getRequest
+
+
+def extract_segments(obj) -> list[str]:
+    """Text segments of a content object, in document order."""
+    segments = []
+    title = obj.Title()
+    if title and title.strip():
+        segments.append(title)
+    description = obj.Description()
+    if description and description.strip():
+        segments.append(description)
+    if IBlocks.providedBy(obj):
+        request = getRequest()
+        blocks = getattr(obj, "blocks", None) or {}
+        blocks_layout = getattr(obj, "blocks_layout", None) or {}
+        for block_id in blocks_layout.get("items", []):
+            block = blocks.get(block_id, {})
+            text = extract_text(block, obj, request)
+            if text and text.strip():
+                segments.append(text)
+    return segments

--- a/backend/src/kitconcept/solr/rag/processor.py
+++ b/backend/src/kitconcept/solr/rag/processor.py
@@ -1,0 +1,236 @@
+"""Indexing queue processor that maintains RAG chunk documents.
+
+Registered as an ``IIndexQueueProcessor`` utility next to
+collective.solr's own processor, so it receives the same
+index/reindex/unindex calls from the Plone indexing queue and writes
+chunk sibling documents (see the schema comment on ``is_rag_chunk``)
+over the same Solr connection.
+
+Design decisions (see IMPLEMENTATION-79.md):
+
+- Embedding is synchronous with a short timeout; an embedding failure
+  logs a warning and leaves the previously indexed chunks in place —
+  a content save must never fail or lose search because the LLM stack
+  is down.
+- A reindex limited to attributes that don't affect the extracted text
+  only updates the denormalized chunk metadata (security, language,
+  path) in place via Solr atomic updates — no re-embedding e.g. on a
+  workflow transition.
+- Chunk cleanup on unindex is gated only on the registry toggle (not
+  on the endpoint configuration), so chunks written earlier are still
+  cleaned up while the endpoint is unconfigured.
+"""
+
+from collective.solr.indexer import SolrIndexProcessor
+from collective.solr.interfaces import ICheckIndexable
+from collective.solr.interfaces import ISolrConnectionManager
+from collective.solr.parser import SolrResponse
+from collective.solr.utils import prepareData
+from kitconcept.solr.rag.chunker import chunk_segments
+from kitconcept.solr.rag.client import LLMClient
+from kitconcept.solr.rag.client import LLMClientError
+from kitconcept.solr.rag.config import get_rag_config
+from kitconcept.solr.rag.config import rag_enabled
+from kitconcept.solr.rag.extraction import extract_segments
+from plone.registry.interfaces import IRegistry
+from plone.uuid.interfaces import IUUID
+from Products.CMFCore.interfaces import IIndexQueueProcessor
+from zope.component import getUtility
+from zope.component import queryUtility
+from zope.interface import implementer
+
+import logging
+
+
+logger = logging.getLogger("kitconcept.solr.rag")
+
+# Attribute reindexes intersecting this set require re-chunking and
+# re-embedding.
+TEXT_ATTRIBUTES = frozenset({"SearchableText", "Title", "Description"})
+# Attribute reindexes intersecting this set update the denormalized
+# chunk metadata in place (no re-embedding).
+METADATA_ATTRIBUTES = frozenset({
+    "allowedRolesAndUsers",
+    "Language",
+    "path",
+    "path_string",
+    "path_parents",
+    "path_depth",
+})
+# Parent fields denormalized onto every chunk document.
+PARENT_DATA_ATTRIBUTES = [
+    "Title",
+    "allowedRolesAndUsers",
+    "Language",
+    "path_string",
+    "path_parents",
+    "path_depth",
+]
+# Safety cap against pathological documents: at ~400 tokens per chunk
+# this covers roughly 40k tokens of text per document.
+MAX_CHUNKS_PER_DOCUMENT = 100
+
+
+def chunk_uid(uid: str, index: int) -> str:
+    return f"{uid}#rag-{index}"
+
+
+def chunk_query(uid: str) -> str:
+    return f'+parent_uid:"{uid}" +is_rag_chunk:true'
+
+
+@implementer(IIndexQueueProcessor)
+class RagIndexProcessor:
+    """Maintain RAG chunk documents alongside regular Solr indexing."""
+
+    def __init__(self, manager=None):
+        self.manager = manager
+
+    def _get_manager(self):
+        return self.manager or queryUtility(ISolrConnectionManager)
+
+    def _connection(self):
+        manager = self._get_manager()
+        if manager is None:
+            return None, None
+        # Returns None while collective.solr is inactive.
+        return manager, manager.getConnection()
+
+    def _commit_within(self):
+        registry = getUtility(IRegistry)
+        return registry["collective.solr.commit_within"]
+
+    def _parent_data(self, obj, manager) -> dict:
+        """Parent field values, mangled the way Solr expects them."""
+        proc = SolrIndexProcessor(manager)
+        data, _missing = proc.getData(obj, attributes=PARENT_DATA_ATTRIBUTES)
+        prepareData(data)
+        return data
+
+    def _chunk_uids(self, conn, uid: str) -> list[str]:
+        """UIDs of the currently indexed chunks of a parent document."""
+        response = conn.search(
+            q=chunk_query(uid),
+            fl="UID",
+            rows=MAX_CHUNKS_PER_DOCUMENT * 2,
+        )
+        try:
+            results = SolrResponse(response).results()
+        finally:
+            response.close()
+        return [flare["UID"] for flare in results]
+
+    # IIndexQueueProcessor
+
+    def index(self, obj, attributes=None):
+        config = get_rag_config()
+        if config is None:
+            return
+        if not ICheckIndexable(obj)():
+            return
+        uid = IUUID(obj, None)
+        if uid is None:
+            return
+        manager, conn = self._connection()
+        if conn is None:
+            return
+        if attributes is not None:
+            attributes = set(attributes)
+            if attributes & TEXT_ATTRIBUTES:
+                pass  # text changed: full rebuild below
+            elif attributes & METADATA_ATTRIBUTES:
+                self._update_chunk_metadata(obj, uid, manager, conn)
+                return
+            else:
+                return  # nothing relevant for the chunks changed
+        self._rebuild_chunks(obj, uid, config, manager, conn)
+
+    def reindex(self, obj, attributes=None, update_metadata=False):
+        if not attributes:
+            attributes = None
+        self.index(obj, attributes)
+
+    def unindex(self, obj):
+        # Gate on the toggle only: cleanup must work without the
+        # endpoint being configured.
+        if not rag_enabled():
+            return
+        # remove the PathWrapper (see SolrIndexProcessor.unindex)
+        if hasattr(obj, "context"):
+            obj = obj.context
+        uid = IUUID(obj, None)
+        if uid is None:
+            return
+        _manager, conn = self._connection()
+        if conn is None:
+            return
+        conn.deleteByQuery(chunk_query(uid))
+
+    def begin(self):
+        pass
+
+    def commit(self, wait=None):
+        # The shared connection is committed by collective.solr's own
+        # queue processor (or by commitWithin on our updates).
+        pass
+
+    def abort(self):
+        pass
+
+    # internal
+
+    def _rebuild_chunks(self, obj, uid, config, manager, conn):
+        segments = extract_segments(obj)
+        chunks = chunk_segments(segments)
+        if len(chunks) > MAX_CHUNKS_PER_DOCUMENT:
+            logger.warning(
+                "%s: truncating %d chunks to %d",
+                uid,
+                len(chunks),
+                MAX_CHUNKS_PER_DOCUMENT,
+            )
+            chunks = chunks[:MAX_CHUNKS_PER_DOCUMENT]
+        try:
+            vectors = LLMClient(config).embed_documents(chunks) if chunks else []
+        except LLMClientError as e:
+            # Never fail (or lose chunks) on an unavailable LLM stack:
+            # keep whatever chunks are currently indexed.
+            logger.warning("%s: embedding failed, keeping existing chunks: %s", uid, e)
+            return
+        parent = self._parent_data(obj, manager)
+        commit_within = self._commit_within()
+        # Delete first: the number of chunks may have shrunk.
+        conn.deleteByQuery(chunk_query(uid))
+        for index, (chunk, vector) in enumerate(zip(chunks, vectors, strict=True)):
+            data = {
+                "UID": chunk_uid(uid, index),
+                "is_rag_chunk": "true",
+                "parent_uid": uid,
+                "chunk_index": index,
+                "chunk_text": chunk,
+                "parent_title": parent.get("Title", ""),
+                "rag_embedding_model": config.embed_model,
+                "content_vector": vector,
+            }
+            for name in PARENT_DATA_ATTRIBUTES:
+                if name != "Title" and name in parent:
+                    data[name] = parent[name]
+            if commit_within:
+                data["commitWithin"] = commit_within
+            conn.add(**data)
+        logger.debug("%s: indexed %d chunks", uid, len(chunks))
+
+    def _update_chunk_metadata(self, obj, uid, manager, conn):
+        """Update denormalized fields on existing chunks in place."""
+        parent = self._parent_data(obj, manager)
+        commit_within = self._commit_within()
+        for existing_uid in self._chunk_uids(conn, uid):
+            data = {"UID": existing_uid}
+            for name in PARENT_DATA_ATTRIBUTES:
+                if name != "Title" and name in parent:
+                    data[name] = parent[name]
+            if commit_within:
+                data["commitWithin"] = commit_within
+            # conn.add issues per-field update="set" operations, so
+            # this is an atomic update of the metadata fields only.
+            conn.add(**data)

--- a/backend/src/kitconcept/solr/rag/reindex.py
+++ b/backend/src/kitconcept/solr/rag/reindex.py
@@ -1,0 +1,53 @@
+"""Full reindex of the RAG chunk documents.
+
+collective.solr's ``@@solr-maintenance`` reindex walks the content
+objects and talks to Solr directly, bypassing the indexing queue
+processors — so a full reindex would never (re)build the RAG chunks.
+This module provides the equivalent pass for the chunks; it is called
+from ``reindex_helpers.reindex`` after the regular Solr reindex.
+"""
+
+from collective.solr.interfaces import ICheckIndexable
+from collective.solr.interfaces import ISolrConnectionManager
+from collective.solr.utils import findObjects
+from kitconcept.solr.rag.config import get_rag_config
+from kitconcept.solr.rag.processor import RagIndexProcessor
+from zope.component import queryUtility
+
+import logging
+
+
+logger = logging.getLogger("kitconcept.solr.rag")
+
+COMMIT_BATCH = 100
+
+
+def reindex_rag(portal) -> int:
+    """Rebuild the RAG chunk documents for all indexable content.
+
+    Returns the number of processed objects. A no-op (returning 0)
+    when the RAG feature is not enabled and configured.
+    """
+    config = get_rag_config()
+    if config is None:
+        logger.info("RAG is not enabled/configured, skipping chunk reindex.")
+        return 0
+    manager = queryUtility(ISolrConnectionManager, context=portal)
+    conn = manager.getConnection() if manager is not None else None
+    if conn is None:
+        logger.warning("No Solr connection, skipping chunk reindex.")
+        return 0
+    processor = RagIndexProcessor(manager)
+    logger.info("Reindexing RAG chunks...")
+    processed = 0
+    for _path, obj in findObjects(portal):
+        if not ICheckIndexable(obj)():
+            continue
+        processor.index(obj)
+        processed += 1
+        if processed % COMMIT_BATCH == 0:
+            conn.commit(soft=True)
+            logger.info("intermediate commit (%d items processed)", processed)
+    conn.commit(soft=True)
+    logger.info("RAG chunk reindex done, %d items processed.", processed)
+    return processed

--- a/backend/src/kitconcept/solr/reindex_helpers.py
+++ b/backend/src/kitconcept/solr/reindex_helpers.py
@@ -1,4 +1,5 @@
 from collective.solr.interfaces import ISolrConnectionManager
+from kitconcept.solr.rag.reindex import reindex_rag
 from plone import api
 from zope.component import queryUtility
 
@@ -29,6 +30,16 @@ def activate(active=True):
     api.portal.set_registry_record("collective.solr.active", active)
 
 
+def set_rag_enabled(enabled):
+    """Switch the RAG (AI search) registry toggle on or off.
+
+    A runtime switch (no restart needed) - the effective availability
+    additionally requires the LLM endpoint env vars, see
+    kitconcept.solr.rag.config.get_rag_config.
+    """
+    api.portal.set_registry_record("kitconcept.solr.rag_enabled", enabled)
+
+
 def silence_logger():
     orig_logger_exception = indexer_logger.exception
 
@@ -56,13 +67,23 @@ def reindex(portal, clear=False):
     logger.info("Reindexing solr...")
     maintenance.reindex()
     reactivate_logger()
+    # The maintenance view above talks to Solr directly, bypassing the
+    # indexing queue processors - the RAG chunks need their own pass.
+    # (No-op unless the RAG feature is enabled and configured.)
+    reindex_rag(portal)
 
 
-def activate_and_reindex(portal, clear=False):
+def activate_and_reindex(portal, clear=False, rag=None):
     # Activate before confirming solr is running,
     # because the confirmation only works if solr is enabled in the registry.
     # If solr isn't running, we'll exit
     # before committing the transaction with the activation.
     activate()
+    if rag is not None:
+        # Set before reindexing, so that enabling also builds the RAG
+        # chunks in the same pass. Note: disabling does not remove
+        # already indexed chunks (they stay invisible and harmless);
+        # a clear reindex removes them.
+        set_rag_enabled(rag)
     if solr_must_be_running(portal):
         reindex(portal, clear=clear)

--- a/backend/src/kitconcept/solr/services/configure.zcml
+++ b/backend/src/kitconcept/solr/services/configure.zcml
@@ -21,6 +21,16 @@
       name="@solr-suggest"
       />
 
+  <!-- RAG: TESTING - rough draft of the RAG query pipeline, to be
+       replaced by the proper implementation (query pipeline ticket) -->
+  <plone:service
+      method="GET"
+      factory=".rag_search.RagSearch"
+      for="zope.interface.Interface"
+      permission="zope2.View"
+      name="@rag-search"
+      />
+
   <adapter factory=".site.CollectiveSolrExpander" />
 
   <adapter

--- a/backend/src/kitconcept/solr/services/rag_search.py
+++ b/backend/src/kitconcept/solr/services/rag_search.py
@@ -1,0 +1,131 @@
+"""Minimal @rag-search endpoint for local testing (RAG: TESTING).
+
+Rough draft of the RAG query pipeline (retrieval endpoint + answer
+generation, internal ticket 458), added ahead of time so the feature
+can be exercised from the site. To be replaced by the proper
+implementation; kept deliberately simple.
+"""
+
+from collective.solr.interfaces import ISolrConnectionManager
+from collective.solr.parser import SolrResponse
+from kitconcept.solr.rag.client import LLMClient
+from kitconcept.solr.rag.client import LLMClientError
+from kitconcept.solr.rag.config import get_rag_config
+from kitconcept.solr.services.solr import security_filter
+from plone import api
+from plone.restapi.services import Service
+from zExceptions import BadRequest
+from zope.component import queryUtility
+
+import logging
+import re
+
+
+logger = logging.getLogger("kitconcept.solr.rag")
+
+TOP_K = 5
+
+SYSTEM_PROMPT = (
+    "You are the search assistant of an intranet site. Answer the"
+    " user's question based only on the provided context documents."
+    " If the answer is not contained in them, say that you could not"
+    " find the answer in the documentation. Answer in the language of"
+    " the question. Be concise: one or two short paragraphs."
+)
+
+PROMPT_TEMPLATE = (
+    "Context documents:\n\n{context}\n\n"
+    "Question: {question}\n\n"
+    "Answer the question based only on the context documents above."
+)
+
+# qwen3 may emit a thinking block; never show it to the user.
+THINK_RE = re.compile(r"<think>.*?</think>\s*", re.DOTALL)
+
+
+class RagSearch(Service):
+    """Single-turn RAG search: question -> answer + sources."""
+
+    def reply(self):
+        question = self.request.form.get("q", "").strip()
+        if not question:
+            raise BadRequest("Missing parameter: q")
+        config = get_rag_config()
+        if config is None:
+            return self._error("RAG is not enabled or not configured")
+        client = LLMClient(config)
+        try:
+            vector = client.embed_query(question)
+        except LLMClientError as e:
+            logger.warning("rag-search: embedding failed: %s", e)
+            return self._error(f"embedding failed: {e}")
+        chunks = self._search_chunks(vector)
+        if not chunks:
+            return {"answer": None, "sources": [], "error": None}
+        prompt = self._build_prompt(question, chunks)
+        sources = self._sources(chunks)
+        try:
+            answer = client.chat(prompt, system=SYSTEM_PROMPT)
+        except LLMClientError as e:
+            logger.warning("rag-search: generation failed: %s", e)
+            return {
+                "answer": None,
+                "sources": sources,
+                "error": f"answer generation failed: {e}",
+            }
+        answer = THINK_RE.sub("", answer).strip()
+        return {"answer": answer, "sources": sources, "error": None}
+
+    def _error(self, message):
+        return {"answer": None, "sources": [], "error": message}
+
+    def _search_chunks(self, vector) -> list[dict]:
+        manager = queryUtility(ISolrConnectionManager)
+        conn = manager.getConnection() if manager is not None else None
+        if conn is None:
+            return []
+        vector_str = "[" + ",".join(f"{x:.8f}" for x in vector) + "]"
+        response = conn.search(
+            q=f"{{!knn f=content_vector topK={TOP_K}}}{vector_str}",
+            fq=[security_filter(), "is_rag_chunk:true"],
+            fl="UID,parent_uid,parent_title,chunk_text,path_string,score",
+            rows=TOP_K,
+        )
+        try:
+            return list(SolrResponse(response).results())
+        finally:
+            response.close()
+
+    def _build_prompt(self, question, chunks) -> str:
+        parts = []
+        for index, chunk in enumerate(chunks, start=1):
+            title = chunk.get("parent_title", "")
+            text = chunk.get("chunk_text", "")
+            parts.append(f"[{index}] {title}\n{text}")
+        return PROMPT_TEMPLATE.format(context="\n\n".join(parts), question=question)
+
+    def _sources(self, chunks) -> list[dict]:
+        """Parent documents of the matched chunks, in rank order."""
+        portal = api.portal.get()
+        portal_path = "/".join(portal.getPhysicalPath())
+        portal_url = portal.absolute_url()
+        seen = set()
+        sources = []
+        for chunk in chunks:
+            parent_uid = chunk.get("parent_uid")
+            if not parent_uid or parent_uid in seen:
+                continue
+            seen.add(parent_uid)
+            path_string = chunk.get("path_string", "")
+            url = (
+                portal_url + path_string[len(portal_path) :]
+                if path_string.startswith(portal_path)
+                else path_string
+            )
+            sources.append({
+                "@id": url,
+                "UID": parent_uid,
+                "title": chunk.get("parent_title", ""),
+                "snippet": chunk.get("chunk_text", "")[:300],
+            })
+        return sources

--- a/backend/src/kitconcept/solr/services/site.py
+++ b/backend/src/kitconcept/solr/services/site.py
@@ -1,5 +1,6 @@
 from collective.solr.utils import isActive
 from kitconcept.solr.interfaces import IKitconceptSolrLayer
+from kitconcept.solr.rag.config import get_rag_config
 from zope.component import adapter
 from zope.interface import implementer
 from zope.interface import Interface
@@ -16,7 +17,19 @@ except ImportError:
 @adapter(Interface, IKitconceptSolrLayer)
 @implementer(ISiteEndpointExpander)
 class CollectiveSolrExpander:
-    """Add collective.solr.active to the @site endpoint"""
+    """Add solr/RAG availability to the @site endpoint.
+
+    The @site endpoint is loaded by Volto on every SSR page load into
+    the redux store, so the client knows these values before the first
+    render.
+
+    kitconcept.solr.rag_available carries the EFFECTIVE state of the
+    AI search: the registry toggle is on AND the LLM endpoint
+    credentials are configured. Decision: graceful degradation - a
+    toggle without credentials (or a downed AI service) silently falls
+    back to the classic search instead of raising a hard error (see
+    SPECIFICATION-79.md, decisions record).
+    """
 
     def __init__(self, context, request):
         self.context = context
@@ -24,3 +37,4 @@ class CollectiveSolrExpander:
 
     def __call__(self, data):
         data["collective.solr.active"] = isActive()
+        data["kitconcept.solr.rag_available"] = get_rag_config() is not None

--- a/backend/src/kitconcept/solr/services/solr.py
+++ b/backend/src/kitconcept/solr/services/solr.py
@@ -179,7 +179,10 @@ class SolrSearch(Service):
             "wt": "json",
             "hl": "true" if highlighting_utils.enabled else "false",
             "hl.fl": highlighting_utils.fields,
-            "fq": [security_filter()],
+            # RAG chunk documents carry no indexed text fields, so they
+            # cannot match the query above; the filter is defense in
+            # depth to keep them out of search results in any case.
+            "fq": [security_filter(), "-is_rag_chunk:true"],
             "fl": solr_config.field_list,
             "facet": "true",
             "facet.contains.ignoreCase": "true",

--- a/backend/src/kitconcept/solr/upgrades/configure.zcml
+++ b/backend/src/kitconcept/solr/upgrades/configure.zcml
@@ -37,4 +37,19 @@
         />
   </genericsetup:upgradeSteps>
 
+  <genericsetup:upgradeSteps
+      profile="kitconcept.solr:default"
+      source="1003"
+      destination="1004"
+      >
+    <genericsetup:upgradeStep
+        title="Add the rag_enabled registry record (AI search toggle)"
+        handler=".update_registry_schema"
+        />
+    <genericsetup:upgradeDepends
+        title="Register the RAG indexing queue processor"
+        import_steps="componentregistry"
+        />
+  </genericsetup:upgradeSteps>
+
 </configure>

--- a/backend/tests/rag/test_chunker.py
+++ b/backend/tests/rag/test_chunker.py
@@ -1,0 +1,92 @@
+from itertools import pairwise
+from kitconcept.solr.rag.chunker import chunk_segments
+from kitconcept.solr.rag.chunker import split_long_text
+from kitconcept.solr.rag.config import CHUNK_MIN_CHARS
+from kitconcept.solr.rag.config import CHUNK_OVERLAP_CHARS
+from kitconcept.solr.rag.config import CHUNK_TARGET_CHARS
+
+
+def sentences(count: int, length: int = 60, marker: str = "s") -> str:
+    """A text of `count` sentences, each ~`length` chars."""
+    parts = []
+    for i in range(count):
+        body = f"Sentence {marker}{i} " + "word " * ((length - 20) // 5)
+        parts.append(body.strip() + ".")
+    return " ".join(parts)
+
+
+HARD_CAP = CHUNK_TARGET_CHARS + CHUNK_MIN_CHARS
+
+
+class TestChunkSegments:
+    def test_empty_input(self):
+        assert chunk_segments([]) == []
+        assert chunk_segments(["", "   ", "\n\t"]) == []
+
+    def test_single_small_segment_is_one_chunk(self):
+        assert chunk_segments(["A short paragraph."]) == ["A short paragraph."]
+
+    def test_small_segments_are_packed_together(self):
+        segments = ["First paragraph.", "Second paragraph.", "Third paragraph."]
+        chunks = chunk_segments(segments)
+        assert chunks == ["First paragraph. Second paragraph. Third paragraph."]
+
+    def test_whitespace_is_normalized(self):
+        chunks = chunk_segments(["A  text\nwith   messy\t\twhitespace."])
+        assert chunks == ["A text with messy whitespace."]
+
+    def test_no_chunk_exceeds_target_plus_merge_slack(self):
+        segments = [sentences(6, marker=f"p{p}") for p in range(20)]
+        chunks = chunk_segments(segments)
+        assert len(chunks) > 1
+        assert all(len(chunk) <= HARD_CAP for chunk in chunks)
+
+    def test_consecutive_chunks_overlap(self):
+        segments = [sentences(6, marker=f"p{p}") for p in range(20)]
+        chunks = chunk_segments(segments)
+        for previous, following in pairwise(chunks):
+            # The following chunk starts with a tail of the previous.
+            overlap_probe = following[: CHUNK_OVERLAP_CHARS // 4]
+            assert overlap_probe.split()[0] in previous
+
+    def test_all_content_is_preserved(self):
+        segments = [sentences(6, marker=f"p{p}") for p in range(10)]
+        chunks = chunk_segments(segments)
+        joined = " ".join(chunks)
+        for p in range(10):
+            for i in range(6):
+                assert f"Sentence p{p}{i}" in joined
+
+    def test_tiny_trailing_rest_is_merged(self):
+        # One target-filling segment plus a tiny one: the tiny rest must
+        # not become a chunk of its own.
+        big = "x" * (CHUNK_TARGET_CHARS - 10) + "."
+        chunks = chunk_segments([big, "Tiny rest."])
+        assert len(chunks) == 1 or all(
+            len(chunk) >= CHUNK_MIN_CHARS for chunk in chunks
+        )
+
+
+class TestSplitLongText:
+    def test_short_text_untouched(self):
+        assert split_long_text("short", 100) == ["short"]
+
+    def test_splits_at_sentence_boundaries(self):
+        text = sentences(10)
+        pieces = split_long_text(text, 200)
+        assert len(pieces) > 1
+        assert all(len(piece) <= 200 for piece in pieces)
+        # Sentence-boundary splits end with the sentence period.
+        assert all(piece.endswith(".") for piece in pieces)
+
+    def test_overlong_sentence_falls_back_to_word_boundary(self):
+        text = "word " * 100  # one 500-char "sentence", no sentence end
+        pieces = split_long_text(text.strip(), 120)
+        assert all(len(piece) <= 120 for piece in pieces)
+        assert all(not piece.startswith(" ") for piece in pieces)
+
+    def test_unbroken_run_is_hard_cut(self):
+        text = "x" * 500
+        pieces = split_long_text(text, 120)
+        assert all(len(piece) <= 120 for piece in pieces)
+        assert "".join(pieces) == text

--- a/backend/tests/rag/test_client.py
+++ b/backend/tests/rag/test_client.py
@@ -1,0 +1,158 @@
+from kitconcept.solr.rag.client import LLMClient
+from kitconcept.solr.rag.client import LLMClientError
+from kitconcept.solr.rag.client import LLMResponseError
+from kitconcept.solr.rag.client import LLMTimeout
+from kitconcept.solr.rag.client import SEARCH_DOCUMENT_PREFIX
+from kitconcept.solr.rag.client import SEARCH_QUERY_PREFIX
+from kitconcept.solr.rag.config import RagConfig
+from unittest import mock
+
+import pytest
+import requests
+
+
+@pytest.fixture
+def config() -> RagConfig:
+    return RagConfig(
+        base_url="http://llm.example.com",
+        token="secret",
+        embed_model="test-embed",
+        chat_model="test-chat",
+    )
+
+
+@pytest.fixture
+def client(config) -> LLMClient:
+    return LLMClient(config)
+
+
+def embed_response(inputs):
+    response = mock.Mock()
+    response.status_code = 200
+    response.json.return_value = {"embeddings": [[0.1, 0.2] for _ in inputs]}
+    return response
+
+
+class TestEmbed:
+    def test_document_prefix_applied(self, client):
+        with mock.patch.object(requests, "post") as post:
+            post.side_effect = lambda url, json, **kw: embed_response(json["input"])
+            client.embed_documents(["hello", "world"])
+        sent = post.call_args.kwargs["json"]["input"]
+        assert sent == [
+            f"{SEARCH_DOCUMENT_PREFIX}hello",
+            f"{SEARCH_DOCUMENT_PREFIX}world",
+        ]
+
+    def test_query_prefix_applied(self, client):
+        with mock.patch.object(requests, "post") as post:
+            post.side_effect = lambda url, json, **kw: embed_response(json["input"])
+            vector = client.embed_query("what is the leave policy?")
+        sent = post.call_args.kwargs["json"]["input"]
+        assert sent == [f"{SEARCH_QUERY_PREFIX}what is the leave policy?"]
+        assert vector == [0.1, 0.2]
+
+    def test_batching(self, client):
+        texts = [f"text {i}" for i in range(70)]
+        with mock.patch.object(requests, "post") as post:
+            post.side_effect = lambda url, json, **kw: embed_response(json["input"])
+            vectors = client.embed_documents(texts)
+        # 70 texts with batch size 32 -> 3 requests
+        assert post.call_count == 3
+        assert len(vectors) == 70
+
+    def test_url_and_auth_header(self, client):
+        with mock.patch.object(requests, "post") as post:
+            post.side_effect = lambda url, json, **kw: embed_response(json["input"])
+            client.embed_documents(["hello"])
+        assert post.call_args.args[0] == "http://llm.example.com/ollama/api/embed"
+        assert post.call_args.kwargs["headers"]["Authorization"] == "Bearer secret"
+
+    def test_no_token_no_auth_header(self, config):
+        client = LLMClient(
+            RagConfig(
+                base_url=config.base_url,
+                token=None,
+                embed_model=config.embed_model,
+                chat_model=config.chat_model,
+            )
+        )
+        with mock.patch.object(requests, "post") as post:
+            post.side_effect = lambda url, json, **kw: embed_response(json["input"])
+            client.embed_documents(["hello"])
+        assert "Authorization" not in post.call_args.kwargs["headers"]
+
+    def test_timeout_maps_to_typed_error(self, client):
+        with (
+            mock.patch.object(requests, "post", side_effect=requests.Timeout),
+            pytest.raises(LLMTimeout),
+        ):
+            client.embed_documents(["hello"])
+
+    def test_connection_error_maps_to_typed_error(self, client):
+        with (
+            mock.patch.object(requests, "post", side_effect=requests.ConnectionError),
+            pytest.raises(LLMClientError),
+        ):
+            client.embed_documents(["hello"])
+
+    def test_http_error_status(self, client):
+        response = mock.Mock()
+        response.status_code = 503
+        response.text = "unavailable"
+        with (
+            mock.patch.object(requests, "post", return_value=response),
+            pytest.raises(LLMResponseError),
+        ):
+            client.embed_documents(["hello"])
+
+    def test_embedding_count_mismatch(self, client):
+        response = mock.Mock()
+        response.status_code = 200
+        response.json.return_value = {"embeddings": [[0.1]]}
+        with (
+            mock.patch.object(requests, "post", return_value=response),
+            pytest.raises(LLMResponseError),
+        ):
+            client.embed_documents(["hello", "world"])
+
+    def test_overlong_input_logs_warning(self, client, caplog):
+        long_text = "word " * 1000
+        with mock.patch.object(requests, "post") as post:
+            post.side_effect = lambda url, json, **kw: embed_response(json["input"])
+            with caplog.at_level("WARNING", logger="kitconcept.solr.rag"):
+                client.embed_documents([long_text])
+        assert any("truncated" in r.message for r in caplog.records)
+
+
+class TestChat:
+    def chat_response(self, content="the answer"):
+        response = mock.Mock()
+        response.status_code = 200
+        response.json.return_value = {"choices": [{"message": {"content": content}}]}
+        return response
+
+    def test_basic_answer(self, client):
+        with mock.patch.object(
+            requests, "post", return_value=self.chat_response()
+        ) as post:
+            answer = client.chat("a question", system="a system prompt")
+        assert answer == "the answer"
+        assert post.call_args.args[0] == "http://llm.example.com/api/chat/completions"
+        payload = post.call_args.kwargs["json"]
+        assert payload["stream"] is False
+        assert payload["messages"][0] == {
+            "role": "system",
+            "content": "a system prompt",
+        }
+        assert payload["messages"][1] == {"role": "user", "content": "a question"}
+
+    def test_unexpected_shape(self, client):
+        response = mock.Mock()
+        response.status_code = 200
+        response.json.return_value = {"unexpected": True}
+        with (
+            mock.patch.object(requests, "post", return_value=response),
+            pytest.raises(LLMResponseError),
+        ):
+            client.chat("a question")

--- a/backend/tests/rag/test_config.py
+++ b/backend/tests/rag/test_config.py
@@ -1,0 +1,67 @@
+from kitconcept.solr.rag import config
+from unittest import mock
+
+import pytest
+
+
+@pytest.fixture
+def enabled_toggle():
+    """Pretend the registry toggle is on."""
+    with mock.patch.object(config, "rag_enabled", return_value=True):
+        yield
+
+
+class TestGetRagConfig:
+    def test_disabled_toggle_returns_none(self, monkeypatch):
+        monkeypatch.setenv(config.ENV_URL, "http://llm.example.com")
+        with mock.patch.object(config, "rag_enabled", return_value=False):
+            assert config.get_rag_config() is None
+
+    def test_no_url_returns_none(self, enabled_toggle, monkeypatch):
+        monkeypatch.delenv(config.ENV_URL, raising=False)
+        assert config.get_rag_config() is None
+
+    def test_defaults(self, enabled_toggle, monkeypatch):
+        monkeypatch.setenv(config.ENV_URL, "http://llm.example.com/")
+        for name in (
+            config.ENV_TOKEN,
+            config.ENV_EMBED_MODEL,
+            config.ENV_CHAT_MODEL,
+            config.ENV_EMBED_PATH,
+            config.ENV_CHAT_PATH,
+        ):
+            monkeypatch.delenv(name, raising=False)
+        cfg = config.get_rag_config()
+        assert cfg.base_url == "http://llm.example.com"  # trailing / stripped
+        assert cfg.token is None
+        assert cfg.embed_model == config.DEFAULT_EMBED_MODEL
+        assert cfg.chat_model == config.DEFAULT_CHAT_MODEL
+        assert cfg.embed_path == config.DEFAULT_EMBED_PATH
+        assert cfg.chat_path == config.DEFAULT_CHAT_PATH
+
+    def test_env_overrides(self, enabled_toggle, monkeypatch):
+        monkeypatch.setenv(config.ENV_URL, "http://llm.example.com")
+        monkeypatch.setenv(config.ENV_TOKEN, "secret")
+        monkeypatch.setenv(config.ENV_EMBED_MODEL, "custom-embed")
+        monkeypatch.setenv(config.ENV_CHAT_MODEL, "custom-chat")
+        monkeypatch.setenv(config.ENV_EMBED_PATH, "/api/embed")
+        monkeypatch.setenv(config.ENV_CHAT_PATH, "/v1/chat/completions")
+        cfg = config.get_rag_config()
+        assert cfg.token == "secret"
+        assert cfg.embed_model == "custom-embed"
+        assert cfg.chat_model == "custom-chat"
+        assert cfg.embed_path == "/api/embed"
+        assert cfg.chat_path == "/v1/chat/completions"
+
+    def test_rag_enabled_without_registry_is_false(self):
+        # Outside a configured Zope site there is no registry utility;
+        # the toggle must default to off instead of breaking.
+        assert config.rag_enabled() is False
+
+
+class TestEstimateTokens:
+    def test_rounds_up(self):
+        assert config.estimate_tokens("abcde") == 2
+
+    def test_empty(self):
+        assert config.estimate_tokens("") == 0

--- a/backend/tests/rag/test_config_registry.py
+++ b/backend/tests/rag/test_config_registry.py
@@ -1,0 +1,29 @@
+from kitconcept.solr.rag import config
+from plone import api
+
+
+class TestRagRegistryToggle:
+    def test_record_exists_and_defaults_to_off(self, portal):
+        value = api.portal.get_registry_record(
+            config.REGISTRY_ENABLED_KEY, default=None
+        )
+        assert value is False
+
+    def test_rag_enabled_follows_registry(self, portal):
+        assert config.rag_enabled() is False
+        api.portal.set_registry_record(config.REGISTRY_ENABLED_KEY, True)
+        try:
+            assert config.rag_enabled() is True
+        finally:
+            api.portal.set_registry_record(config.REGISTRY_ENABLED_KEY, False)
+
+    def test_get_rag_config_needs_toggle_and_url(self, portal, monkeypatch):
+        monkeypatch.setenv(config.ENV_URL, "http://llm.example.com")
+        assert config.get_rag_config() is None  # toggle off
+        api.portal.set_registry_record(config.REGISTRY_ENABLED_KEY, True)
+        try:
+            cfg = config.get_rag_config()
+            assert cfg is not None
+            assert cfg.base_url == "http://llm.example.com"
+        finally:
+            api.portal.set_registry_record(config.REGISTRY_ENABLED_KEY, False)

--- a/backend/tests/rag/test_e2e_live.py
+++ b/backend/tests/rag/test_e2e_live.py
@@ -1,0 +1,133 @@
+"""Live end-to-end test of the RAG indexing path.
+
+Runs only when the LLM endpoint environment variables are present
+(``KITCONCEPT_SOLR_LLM_URL``/``_TOKEN``) — skipped otherwise, so CI is
+unaffected. Requires the docker Solr (like the service tests).
+
+This is the verification flagged in IMPLEMENTATION-79.md: indexing a
+document must create chunk sibling documents with real vectors in Solr
+(via collective.solr's XML update path), and a ``{!knn}`` query with an
+embedded question must retrieve them.
+"""
+
+from kitconcept.solr.rag.client import LLMClient
+from kitconcept.solr.rag.config import get_rag_config
+from plone import api
+from zope.component.hooks import setSite
+
+import os
+import pytest
+import requests
+import transaction
+
+
+LIVE = bool(os.environ.get("KITCONCEPT_SOLR_LLM_URL")) and bool(
+    os.environ.get("KITCONCEPT_SOLR_LLM_TOKEN")
+)
+
+pytestmark = pytest.mark.skipif(
+    not LIVE,
+    reason="live LLM test: KITCONCEPT_SOLR_LLM_URL/_TOKEN not set",
+)
+
+BODY_TEXT = (
+    "Employees are entitled to 30 days of paid vacation per year. "
+    "Vacation requests are submitted through the HR portal and must be "
+    "approved by the team lead."
+)
+
+
+@pytest.fixture()
+def solr_select(solr_service) -> str:
+    """The /select URL of the dockerized Solr core."""
+    return solr_service.split("/admin/")[0] + "/select"
+
+
+@pytest.fixture()
+def portal(functional, solr_service):
+    portal = functional["app"]["plone"]
+    setSite(portal)
+    with api.env.adopt_roles(["Manager", "Member"]):
+        api.portal.set_registry_record("collective.solr.active", True)
+        api.portal.set_registry_record("kitconcept.solr.rag_enabled", True)
+        maintenance = api.content.get_view(
+            "solr-maintenance", portal, functional["request"]
+        )
+        maintenance.clear()
+    transaction.commit()
+    yield portal
+    with api.env.adopt_roles(["Manager"]):
+        if "vacation-policy" in portal:
+            api.content.delete(portal["vacation-policy"])
+        api.portal.set_registry_record("kitconcept.solr.rag_enabled", False)
+        api.portal.set_registry_record("collective.solr.active", False)
+    transaction.commit()
+
+
+def solr_docs(solr_select, **params) -> list[dict]:
+    params = {"wt": "json", "rows": 50, **params}
+    # POST: knn query vectors are far too long for a GET query string
+    response = requests.post(solr_select, data=params, timeout=10)
+    response.raise_for_status()
+    return response.json()["response"]["docs"]
+
+
+class TestLiveIndexing:
+    def test_chunks_indexed_and_knn_retrievable(self, portal, solr_select):
+        with api.env.adopt_roles(["Manager"]):
+            doc = api.content.create(
+                container=portal,
+                type="Document",
+                id="vacation-policy",
+                title="Vacation policy",
+                description="How much annual leave employees get.",
+            )
+            doc.blocks = {"b1": {"@type": "slate", "plaintext": BODY_TEXT}}
+            doc.blocks_layout = {"items": ["b1"]}
+            doc.reindexObject()
+            uid = doc.UID()
+        transaction.commit()  # runs the indexing queue processors
+
+        # 1. chunk sibling documents exist, with the expected fields
+        chunks = solr_docs(
+            solr_select,
+            q=f'parent_uid:"{uid}"',
+            fq="is_rag_chunk:true",
+            fl="UID,parent_uid,chunk_index,chunk_text,parent_title,"
+            "allowedRolesAndUsers,Language,rag_embedding_model",
+        )
+        assert len(chunks) >= 1
+        chunk = chunks[0]
+        assert chunk["UID"] == f"{uid}#rag-0"
+        assert "30 days of paid vacation" in chunk["chunk_text"]
+        assert chunk["parent_title"] == "Vacation policy"
+        assert chunk["allowedRolesAndUsers"]  # security is denormalized
+        assert chunk["rag_embedding_model"]
+
+        # 2. the regular search never returns chunks
+        parents = solr_docs(solr_select, q=f'UID:"{uid}"', fl="UID")
+        assert len(parents) == 1  # the parent itself is indexed normally
+
+        # 3. a {!knn} query with the embedded question retrieves the chunk
+        client = LLMClient(get_rag_config())
+        vector = client.embed_query("How many vacation days do employees get?")
+        vector_str = "[" + ",".join(f"{x:.8f}" for x in vector) + "]"
+        hits = solr_docs(
+            solr_select,
+            **{
+                "q": f"{{!knn f=content_vector topK=5}}{vector_str}",
+                "fq": "is_rag_chunk:true",
+                "fl": "UID,parent_uid,score",
+            },
+        )
+        assert hits, "knn query returned no chunk hits"
+        assert hits[0]["parent_uid"] == uid
+
+        # 4. deleting the content removes its chunks
+        with api.env.adopt_roles(["Manager"]):
+            api.content.delete(portal["vacation-policy"])
+        transaction.commit()
+        remaining = solr_docs(
+            solr_select, q=f'parent_uid:"{uid}"', fq="is_rag_chunk:true"
+        )
+        assert remaining == []

--- a/backend/tests/rag/test_e2e_live_ragsearch.py
+++ b/backend/tests/rag/test_e2e_live_ragsearch.py
@@ -1,0 +1,90 @@
+"""Live test of the minimal @rag-search endpoint (RAG: TESTING).
+
+Same gating as test_e2e_live.py: runs only with the LLM env vars set
+and the docker Solr running. Goes with the throwaway endpoint and is
+removed together with it.
+"""
+
+from plone import api
+from plone.app.testing import SITE_OWNER_NAME
+from plone.app.testing import SITE_OWNER_PASSWORD
+from plone.restapi.testing import RelativeSession
+from zope.component.hooks import setSite
+
+import os
+import pytest
+import transaction
+
+
+LIVE = bool(os.environ.get("KITCONCEPT_SOLR_LLM_URL")) and bool(
+    os.environ.get("KITCONCEPT_SOLR_LLM_TOKEN")
+)
+
+pytestmark = pytest.mark.skipif(
+    not LIVE,
+    reason="live LLM test: KITCONCEPT_SOLR_LLM_URL/_TOKEN not set",
+)
+
+BODY_TEXT = (
+    "Employees are entitled to 30 days of paid vacation per year. "
+    "Vacation requests are submitted through the HR portal and must be "
+    "approved by the team lead."
+)
+
+
+@pytest.fixture()
+def portal(functional, solr_service):
+    portal = functional["app"]["plone"]
+    setSite(portal)
+    with api.env.adopt_roles(["Manager", "Member"]):
+        api.portal.set_registry_record("collective.solr.active", True)
+        api.portal.set_registry_record("kitconcept.solr.rag_enabled", True)
+        maintenance = api.content.get_view(
+            "solr-maintenance", portal, functional["request"]
+        )
+        maintenance.clear()
+        doc = api.content.create(
+            container=portal,
+            type="Document",
+            id="vacation-policy",
+            title="Vacation policy",
+            description="How much annual leave employees get.",
+        )
+        doc.blocks = {"b1": {"@type": "slate", "plaintext": BODY_TEXT}}
+        doc.blocks_layout = {"items": ["b1"]}
+        doc.reindexObject()
+    transaction.commit()
+    yield portal
+    with api.env.adopt_roles(["Manager"]):
+        api.content.delete(portal["vacation-policy"])
+        api.portal.set_registry_record("kitconcept.solr.rag_enabled", False)
+        api.portal.set_registry_record("collective.solr.active", False)
+    transaction.commit()
+
+
+@pytest.fixture()
+def manager_session(portal):
+    session = RelativeSession(portal.absolute_url())
+    session.headers.update({"Accept": "application/json"})
+    session.auth = (SITE_OWNER_NAME, SITE_OWNER_PASSWORD)
+    return session
+
+
+class TestLiveRagSearch:
+    def test_answer_with_sources(self, manager_session):
+        response = manager_session.get(
+            "/@rag-search",
+            params={"q": "How many vacation days do employees get?"},
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["error"] is None
+        assert data["answer"], "expected a generated answer"
+        assert "30" in data["answer"]
+        assert data["sources"]
+        assert data["sources"][0]["title"] == "Vacation policy"
+        assert "<think>" not in data["answer"]
+
+    def test_missing_question_is_bad_request(self, manager_session):
+        response = manager_session.get("/@rag-search")
+        assert response.status_code == 400

--- a/backend/tests/rag/test_processor.py
+++ b/backend/tests/rag/test_processor.py
@@ -1,0 +1,212 @@
+from kitconcept.solr.rag import processor as processor_module
+from kitconcept.solr.rag.client import LLMClientError
+from kitconcept.solr.rag.config import RagConfig
+from kitconcept.solr.rag.processor import chunk_query
+from kitconcept.solr.rag.processor import chunk_uid
+from kitconcept.solr.rag.processor import RagIndexProcessor
+from unittest import mock
+
+import pytest
+
+
+UID = "abcd1234"
+
+CONFIG = RagConfig(
+    base_url="http://llm.example.com",
+    token=None,
+    embed_model="test-embed",
+    chat_model="test-chat",
+)
+
+PARENT_DATA = {
+    "Title": "A document",
+    "allowedRolesAndUsers": ["Anonymous"],
+    "Language": "en",
+    "path_string": "/plone/a-document",
+    "path_parents": ["/plone", "/plone/a-document"],
+    "path_depth": 2,
+}
+
+
+class FakeConnection:
+    def __init__(self):
+        self.added = []
+        self.deleted_queries = []
+
+    def add(self, **fields):
+        self.added.append(fields)
+
+    def deleteByQuery(self, query):
+        self.deleted_queries.append(query)
+
+
+class FakeContextProcessor(RagIndexProcessor):
+    """Processor with the Zope/Solr context faked out for unit tests."""
+
+    def __init__(self, conn, parent_data=PARENT_DATA, commit_within=None):
+        super().__init__(manager=mock.Mock())
+        self._conn = conn
+        self._parent = parent_data
+        self._within = commit_within
+        self.existing_chunk_uids = []
+
+    def _connection(self):
+        return self.manager, self._conn
+
+    def _parent_data(self, obj, manager):
+        return dict(self._parent)
+
+    def _commit_within(self):
+        return self._within
+
+    def _chunk_uids(self, conn, uid):
+        return self.existing_chunk_uids
+
+
+@pytest.fixture
+def conn():
+    return FakeConnection()
+
+
+@pytest.fixture
+def proc(conn):
+    return FakeContextProcessor(conn)
+
+
+@pytest.fixture
+def obj():
+    """A content object double passing ICheckIndexable and IUUID."""
+    fake = mock.Mock()
+    fake.Title.return_value = "A document"
+    fake.Description.return_value = "About something."
+    return fake
+
+
+@pytest.fixture(autouse=True)
+def environment(obj):
+    """Enabled config, indexable object, deterministic embeddings."""
+    with (
+        mock.patch.object(processor_module, "get_rag_config", return_value=CONFIG),
+        mock.patch.object(processor_module, "rag_enabled", return_value=True),
+        mock.patch.object(
+            processor_module, "ICheckIndexable", return_value=lambda: True
+        ),
+        mock.patch.object(processor_module, "IUUID", return_value=UID),
+        mock.patch.object(
+            processor_module,
+            "extract_segments",
+            return_value=["A document", "About something."],
+        ),
+        mock.patch.object(processor_module, "LLMClient") as llm_class,
+    ):
+        llm_class.return_value.embed_documents.side_effect = lambda chunks: [
+            [0.1, 0.2] for _ in chunks
+        ]
+        yield llm_class
+
+
+class TestIndexRebuild:
+    def test_deletes_then_adds_chunks(self, proc, conn, obj):
+        proc.index(obj)
+        assert conn.deleted_queries == [chunk_query(UID)]
+        assert len(conn.added) == 1  # short text: one chunk
+        doc = conn.added[0]
+        assert doc["UID"] == chunk_uid(UID, 0)
+        assert doc["is_rag_chunk"] == "true"
+        assert doc["parent_uid"] == UID
+        assert doc["chunk_index"] == 0
+        assert doc["chunk_text"] == "A document About something."
+        assert doc["parent_title"] == "A document"
+        assert doc["rag_embedding_model"] == "test-embed"
+        assert doc["content_vector"] == [0.1, 0.2]
+
+    def test_denormalizes_security_language_path(self, proc, conn, obj):
+        proc.index(obj)
+        doc = conn.added[0]
+        assert doc["allowedRolesAndUsers"] == ["Anonymous"]
+        assert doc["Language"] == "en"
+        assert doc["path_string"] == "/plone/a-document"
+        assert doc["path_parents"] == ["/plone", "/plone/a-document"]
+        assert doc["path_depth"] == 2
+
+    def test_commit_within_is_propagated(self, conn, obj):
+        proc = FakeContextProcessor(conn, commit_within=10000)
+        proc.index(obj)
+        assert conn.added[0]["commitWithin"] == 10000
+
+    def test_disabled_config_is_a_noop(self, proc, conn, obj):
+        with mock.patch.object(processor_module, "get_rag_config", return_value=None):
+            proc.index(obj)
+        assert conn.added == []
+        assert conn.deleted_queries == []
+
+    def test_no_connection_is_a_noop(self, conn, obj):
+        proc = FakeContextProcessor(conn)
+        proc._connection = lambda: (None, None)
+        proc.index(obj)
+        assert conn.added == []
+
+    def test_embedding_failure_keeps_existing_chunks(
+        self, proc, conn, obj, environment
+    ):
+        environment.return_value.embed_documents.side_effect = LLMClientError("down")
+        proc.index(obj)
+        # neither deleted nor re-added: previously indexed chunks stay
+        assert conn.deleted_queries == []
+        assert conn.added == []
+
+    def test_empty_text_deletes_stale_chunks(self, proc, conn, obj):
+        with mock.patch.object(processor_module, "extract_segments", return_value=[]):
+            proc.index(obj)
+        assert conn.deleted_queries == [chunk_query(UID)]
+        assert conn.added == []
+
+    def test_chunk_cap(self, proc, conn, obj):
+        many = [f"Paragraph {i}. " + "word " * 400 for i in range(300)]
+        with mock.patch.object(processor_module, "extract_segments", return_value=many):
+            proc.index(obj)
+        assert len(conn.added) == processor_module.MAX_CHUNKS_PER_DOCUMENT
+
+
+class TestReindexAttributes:
+    def test_irrelevant_attributes_are_a_noop(self, proc, conn, obj):
+        proc.reindex(obj, attributes=["getObjPositionInParent"])
+        assert conn.added == []
+        assert conn.deleted_queries == []
+
+    def test_text_attribute_triggers_rebuild(self, proc, conn, obj):
+        proc.reindex(obj, attributes=["SearchableText"])
+        assert conn.deleted_queries == [chunk_query(UID)]
+        assert len(conn.added) == 1
+
+    def test_security_attribute_updates_metadata_in_place(self, proc, conn, obj):
+        proc.existing_chunk_uids = [chunk_uid(UID, 0), chunk_uid(UID, 1)]
+        proc.reindex(obj, attributes=["allowedRolesAndUsers"])
+        # no delete, no re-embedding: atomic updates on existing chunks
+        assert conn.deleted_queries == []
+        assert len(conn.added) == 2
+        for doc in conn.added:
+            assert doc["allowedRolesAndUsers"] == ["Anonymous"]
+            assert "content_vector" not in doc
+            assert "chunk_text" not in doc
+
+    def test_empty_attributes_means_full_rebuild(self, proc, conn, obj):
+        proc.reindex(obj, attributes=[])
+        assert conn.deleted_queries == [chunk_query(UID)]
+
+
+class TestUnindex:
+    def test_deletes_chunks(self, proc, conn, obj):
+        proc.unindex(obj)
+        assert conn.deleted_queries == [chunk_query(UID)]
+
+    def test_gated_on_toggle_not_endpoint(self, proc, conn, obj):
+        # endpoint unconfigured, toggle on: cleanup still works
+        with mock.patch.object(processor_module, "get_rag_config", return_value=None):
+            proc.unindex(obj)
+        assert conn.deleted_queries == [chunk_query(UID)]
+
+    def test_toggle_off_is_a_noop(self, proc, conn, obj):
+        with mock.patch.object(processor_module, "rag_enabled", return_value=False):
+            proc.unindex(obj)
+        assert conn.deleted_queries == []

--- a/backend/tests/rag/test_processor_registration.py
+++ b/backend/tests/rag/test_processor_registration.py
@@ -1,0 +1,14 @@
+from kitconcept.solr.rag.processor import RagIndexProcessor
+from Products.CMFCore.interfaces import IIndexQueueProcessor
+from zope.component import getUtilitiesFor
+
+
+class TestQueueProcessorRegistration:
+    def test_utility_registered_on_install(self, portal):
+        utilities = dict(getUtilitiesFor(IIndexQueueProcessor))
+        assert "kitconcept.solr.rag" in utilities
+        assert isinstance(utilities["kitconcept.solr.rag"], RagIndexProcessor)
+
+    def test_collective_solr_processor_still_registered(self, portal):
+        utilities = dict(getUtilitiesFor(IIndexQueueProcessor))
+        assert "solr" in utilities

--- a/backend/tests/rag/test_reindex.py
+++ b/backend/tests/rag/test_reindex.py
@@ -1,0 +1,67 @@
+from kitconcept.solr.rag import reindex as reindex_module
+from kitconcept.solr.rag.config import RagConfig
+from kitconcept.solr.rag.reindex import reindex_rag
+from unittest import mock
+
+
+CONFIG = RagConfig(
+    base_url="http://llm.example.com",
+    token=None,
+    embed_model="test-embed",
+    chat_model="test-chat",
+)
+
+
+class TestReindexRag:
+    def test_disabled_is_a_noop(self):
+        with mock.patch.object(reindex_module, "get_rag_config", return_value=None):
+            assert reindex_rag(mock.Mock()) == 0
+
+    def test_walks_and_indexes_all_content(self):
+        objects = [(f"/plone/doc{i}", mock.Mock()) for i in range(5)]
+        conn = mock.Mock()
+        manager = mock.Mock()
+        manager.getConnection.return_value = conn
+        with (
+            mock.patch.object(reindex_module, "get_rag_config", return_value=CONFIG),
+            mock.patch.object(reindex_module, "queryUtility", return_value=manager),
+            mock.patch.object(
+                reindex_module, "findObjects", return_value=iter(objects)
+            ),
+            mock.patch.object(
+                reindex_module, "ICheckIndexable", return_value=lambda: True
+            ),
+            mock.patch.object(reindex_module, "RagIndexProcessor") as proc_class,
+        ):
+            processed = reindex_rag(mock.Mock())
+        assert processed == 5
+        assert proc_class.return_value.index.call_count == 5
+        conn.commit.assert_called_with(soft=True)
+
+    def test_skips_non_indexable(self):
+        objects = [("/plone/doc", mock.Mock())]
+        manager = mock.Mock()
+        manager.getConnection.return_value = mock.Mock()
+        with (
+            mock.patch.object(reindex_module, "get_rag_config", return_value=CONFIG),
+            mock.patch.object(reindex_module, "queryUtility", return_value=manager),
+            mock.patch.object(
+                reindex_module, "findObjects", return_value=iter(objects)
+            ),
+            mock.patch.object(
+                reindex_module, "ICheckIndexable", return_value=lambda: False
+            ),
+            mock.patch.object(reindex_module, "RagIndexProcessor") as proc_class,
+        ):
+            processed = reindex_rag(mock.Mock())
+        assert processed == 0
+        proc_class.return_value.index.assert_not_called()
+
+    def test_no_connection_is_a_noop(self):
+        manager = mock.Mock()
+        manager.getConnection.return_value = None
+        with (
+            mock.patch.object(reindex_module, "get_rag_config", return_value=CONFIG),
+            mock.patch.object(reindex_module, "queryUtility", return_value=manager),
+        ):
+            assert reindex_rag(mock.Mock()) == 0

--- a/backend/tests/rag/test_reindex_rag_flag.py
+++ b/backend/tests/rag/test_reindex_rag_flag.py
@@ -1,0 +1,35 @@
+from kitconcept.solr import reindex_helpers
+from kitconcept.solr.rag.config import REGISTRY_ENABLED_KEY
+from plone import api
+from unittest import mock
+
+import pytest
+
+
+@pytest.fixture
+def quiet_reindex():
+    """Skip the actual solr reindex parts."""
+    with (
+        mock.patch.object(reindex_helpers, "solr_must_be_running", return_value=False),
+        mock.patch.object(reindex_helpers, "activate"),
+    ):
+        yield
+
+
+class TestActivateAndReindexRagFlag:
+    def test_default_leaves_toggle_unchanged(self, portal, quiet_reindex):
+        assert api.portal.get_registry_record(REGISTRY_ENABLED_KEY) is False
+        reindex_helpers.activate_and_reindex(portal)
+        assert api.portal.get_registry_record(REGISTRY_ENABLED_KEY) is False
+
+    def test_rag_true_enables_toggle(self, portal, quiet_reindex):
+        try:
+            reindex_helpers.activate_and_reindex(portal, rag=True)
+            assert api.portal.get_registry_record(REGISTRY_ENABLED_KEY) is True
+        finally:
+            api.portal.set_registry_record(REGISTRY_ENABLED_KEY, False)
+
+    def test_rag_false_disables_toggle(self, portal, quiet_reindex):
+        api.portal.set_registry_record(REGISTRY_ENABLED_KEY, True)
+        reindex_helpers.activate_and_reindex(portal, rag=False)
+        assert api.portal.get_registry_record(REGISTRY_ENABLED_KEY) is False

--- a/backend/tests/rag/test_site_expander.py
+++ b/backend/tests/rag/test_site_expander.py
@@ -1,0 +1,40 @@
+from kitconcept.solr.rag import config
+from kitconcept.solr.services.site import CollectiveSolrExpander
+from plone import api
+
+
+class TestRagAvailableInSiteExpander:
+    def expand(self, portal):
+        data = {}
+        CollectiveSolrExpander(portal, portal.REQUEST)(data)
+        return data
+
+    def test_unconfigured_site_reports_unavailable(self, portal):
+        # toggle off (default) and/or no credentials
+        data = self.expand(portal)
+        assert data["kitconcept.solr.rag_available"] is False
+
+    def test_toggle_without_credentials_degrades_gracefully(self, portal, monkeypatch):
+        # Decision (graceful degradation): toggle on but no credentials
+        # is NOT an error - the feature reports unavailable and the
+        # classic search is used.
+        monkeypatch.delenv(config.ENV_URL, raising=False)
+        api.portal.set_registry_record(config.REGISTRY_ENABLED_KEY, True)
+        try:
+            data = self.expand(portal)
+            assert data["kitconcept.solr.rag_available"] is False
+        finally:
+            api.portal.set_registry_record(config.REGISTRY_ENABLED_KEY, False)
+
+    def test_toggle_with_credentials_reports_available(self, portal, monkeypatch):
+        monkeypatch.setenv(config.ENV_URL, "http://llm.example.com")
+        api.portal.set_registry_record(config.REGISTRY_ENABLED_KEY, True)
+        try:
+            data = self.expand(portal)
+            assert data["kitconcept.solr.rag_available"] is True
+        finally:
+            api.portal.set_registry_record(config.REGISTRY_ENABLED_KEY, False)
+
+    def test_solr_active_still_exposed(self, portal):
+        data = self.expand(portal)
+        assert "collective.solr.active" in data

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -63,6 +63,9 @@ services:
       COLLECTIVE_SOLR_HOST: solr-acceptance
       COLLECTIVE_SOLR_PORT: 8983
       COLLECTIVE_SOLR_BASE: /solr/plone
+      # RAG / AI search: LLM endpoint (feature is off when unset)
+      KITCONCEPT_SOLR_LLM_URL: ${KITCONCEPT_SOLR_LLM_URL:-}
+      KITCONCEPT_SOLR_LLM_TOKEN: ${KITCONCEPT_SOLR_LLM_TOKEN:-}
     depends_on:
       - solr-acceptance
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -63,6 +63,9 @@ services:
       COLLECTIVE_SOLR_HOST: solr
       COLLECTIVE_SOLR_PORT: 8983
       COLLECTIVE_SOLR_BASE: /solr/plone
+      # RAG / AI search: LLM endpoint (feature is off when unset)
+      KITCONCEPT_SOLR_LLM_URL: ${KITCONCEPT_SOLR_LLM_URL:-}
+      KITCONCEPT_SOLR_LLM_TOKEN: ${KITCONCEPT_SOLR_LLM_TOKEN:-}
     volumes:
       - vol-site-data:/data
     labels:

--- a/frontend/packages/volto-solr/src/actions/index.js
+++ b/frontend/packages/volto-solr/src/actions/index.js
@@ -1,9 +1,14 @@
 import { solrSearchContent, copyContentForSolr } from './solrsearch/solrsearch';
 import { solrSearchSuggestions } from './solrsearch/solrSearchSuggestions';
 import { getNavigationWithExcluded } from './navigation_with_excluded/navigation_with_excluded';
+// RAG: TESTING
+import { ragSearch, resetRagSearch } from './ragsearch/ragsearch';
 export {
   solrSearchContent,
   copyContentForSolr,
   solrSearchSuggestions,
   getNavigationWithExcluded,
+  // RAG: TESTING
+  ragSearch,
+  resetRagSearch,
 };

--- a/frontend/packages/volto-solr/src/actions/ragsearch/ragsearch.js
+++ b/frontend/packages/volto-solr/src/actions/ragsearch/ragsearch.js
@@ -1,0 +1,40 @@
+/**
+ * RAG search actions (RAG: TESTING).
+ *
+ * Calls the minimal @rag-search endpoint: single-turn RAG search,
+ * question -> answer + source documents. Debug plumbing to exercise
+ * the feature from the site; the real search UX lands separately.
+ *
+ * @module actions/ragsearch/ragsearch
+ */
+
+export const RAG_SEARCH = 'RAG_SEARCH';
+export const RESET_RAG_SEARCH = 'RESET_RAG_SEARCH';
+
+/**
+ * RAG search function.
+ * @function ragSearch
+ * @param {string} url Url to use as base.
+ * @param {string} question The natural language question.
+ * @returns {Object} RAG search action.
+ */
+export function ragSearch(url, question) {
+  return {
+    type: RAG_SEARCH,
+    request: {
+      op: 'get',
+      path: `${url}/@rag-search?q=${encodeURIComponent(question)}`,
+    },
+  };
+}
+
+/**
+ * Reset RAG search function.
+ * @function resetRagSearch
+ * @returns {Object} Reset RAG search action.
+ */
+export function resetRagSearch() {
+  return {
+    type: RESET_RAG_SEARCH,
+  };
+}

--- a/frontend/packages/volto-solr/src/components/theme/SolrSearch/SolrSearch.jsx
+++ b/frontend/packages/volto-solr/src/components/theme/SolrSearch/SolrSearch.jsx
@@ -39,6 +39,9 @@ import { SearchTabs } from './SearchTabs';
 import { SearchConditions } from './SearchConditions';
 import { queryStateFromParams, queryStateToParams } from './SearchQuery';
 import { VocabProvider } from './vocabs/VocabContext';
+// RAG: TESTING
+import { ragSearch, resetRagSearch } from '../../../actions';
+import { flattenToAppURL } from '@plone/volto/helpers/Url/Url';
 
 const messages = defineMessages({
   TypeSearchWords: {
@@ -201,6 +204,8 @@ class SolrSearch extends Component {
     batching: null,
     searchableText: null,
     path: null,
+    // RAG: TESTING
+    rag: {},
   };
 
   constructor(props) {
@@ -210,6 +215,8 @@ class SolrSearch extends Component {
       currentPage: 1,
       isClient: false,
       searchwordInStatus: '',
+      // RAG: TESTING - "Use AI" toggle, on by default
+      useAI: true,
     };
     this.inputRef = createRef();
   }
@@ -265,12 +272,28 @@ class SolrSearch extends Component {
    */
   doSearch = (params) => {
     this.setState({ searchwordInStatus: params.SearchableText || '' });
+    // RAG: TESTING - when RAG is available (the @site endpoint
+    // reported the feature enabled and configured, known before the
+    // first render) and the toggle is on, the question goes to the
+    // RAG endpoint instead of the classic solr search
+    if (this.props.ragAvailable && this.state.useAI && params.SearchableText) {
+      this.props.ragSearch('', params.SearchableText);
+      return;
+    }
     this.props.searchContent('', {
       ...params,
       sort_on: params.sort_on !== 'relevance' ? params.sort_on : '',
       b_start: (this.state.currentPage - 1) * config.settings.defaultPageSize,
       path_prefix: getPathPrefix(window.location),
       doEmptySearch: this.props.doEmptySearch,
+    });
+  };
+
+  // RAG: TESTING
+  setUseAI = (checked) => {
+    this.setState({ useAI: checked }, () => {
+      this.props.resetRagSearch();
+      this.doSearch(this.searchParams());
     });
   };
 
@@ -354,6 +377,58 @@ class SolrSearch extends Component {
                   </Button>
                 </div>
               </form>
+            </div>
+          ) : null}
+          {/* RAG: TESTING - debug toggle + answer area (real UX comes
+              from the search modal ticket, styling intentionally raw).
+              Rendered only when the backend reports the feature
+              available - an unconfigured site shows the classic
+              search, untouched. */}
+          {this.props.ragAvailable ? (
+            <div className="rag-debug" style={{ margin: '1em 0' }}>
+              <Checkbox
+                toggle
+                label="Use AI"
+                checked={this.state.useAI}
+                onChange={(e, { checked }) => this.setUseAI(checked)}
+              />
+              {this.state.useAI &&
+              (this.props.rag.loading || this.props.rag.loaded) ? (
+                <div
+                  style={{
+                    border: '1px solid #ccc',
+                    background: '#f8f8f8',
+                    padding: '1em',
+                    marginTop: '0.5em',
+                  }}
+                >
+                  {this.props.rag.loading ? <p>Thinking…</p> : null}
+                  {this.props.rag.error ? (
+                    <p style={{ color: 'red' }}>{this.props.rag.error}</p>
+                  ) : null}
+                  {this.props.rag.answer ? (
+                    <p style={{ whiteSpace: 'pre-wrap' }}>
+                      {this.props.rag.answer}
+                    </p>
+                  ) : null}
+                  {this.props.rag.loaded &&
+                  !this.props.rag.answer &&
+                  !this.props.rag.error ? (
+                    <p>No answer — no matching documents found.</p>
+                  ) : null}
+                  {(this.props.rag.sources || []).length > 0 ? (
+                    <ul>
+                      {this.props.rag.sources.map((source) => (
+                        <li key={source.UID}>
+                          <a href={flattenToAppURL(source['@id'])}>
+                            {source.title}
+                          </a>
+                        </li>
+                      ))}
+                    </ul>
+                  ) : null}
+                </div>
+              ) : null}
             </div>
           ) : null}
           {this.state.allowLocal &&
@@ -544,6 +619,10 @@ export default compose(
         loaded,
         loading,
         batching,
+        // RAG: TESTING
+        rag: state.ragsearch || {},
+        ragAvailable:
+          state?.site?.data?.['kitconcept.solr.rag_available'] === true,
         intl: state.intl,
         pathname: props.history.location.pathname,
         contentTypeSearchResultViews: contentTypeSearchResultViewsWithDefault(
@@ -558,6 +637,9 @@ export default compose(
     (dispatch, { searchAction }) => ({
       searchContent: (...args) =>
         dispatch(searchActionWithDefault(searchAction)(...args)),
+      // RAG: TESTING
+      ragSearch: (...args) => dispatch(ragSearch(...args)),
+      resetRagSearch: () => dispatch(resetRagSearch()),
     }),
   ),
   asyncConnect([

--- a/frontend/packages/volto-solr/src/reducers/index.js
+++ b/frontend/packages/volto-solr/src/reducers/index.js
@@ -1,6 +1,8 @@
 import solrsearch from './solrsearch/solrsearch';
 import solrSearchSuggestions from './solrsearch/solrSearchSuggestions';
 import navigation_with_excluded from './navigation_with_excluded/navigation_with_excluded';
+// RAG: TESTING
+import ragsearch from './ragsearch/ragsearch';
 import { defineMessages } from 'react-intl';
 
 // needed to add as overrides are not parsed by i18n
@@ -38,6 +40,8 @@ const reducers = {
   solrsearch,
   solrSearchSuggestions,
   navigation_with_excluded,
+  // RAG: TESTING
+  ragsearch,
 };
 
 export default reducers;

--- a/frontend/packages/volto-solr/src/reducers/ragsearch/ragsearch.js
+++ b/frontend/packages/volto-solr/src/reducers/ragsearch/ragsearch.js
@@ -1,0 +1,54 @@
+/**
+ * RAG search reducer (RAG: TESTING).
+ * @module reducers/ragsearch/ragsearch
+ */
+
+import {
+  RAG_SEARCH,
+  RESET_RAG_SEARCH,
+} from '../../actions/ragsearch/ragsearch';
+
+const initialState = {
+  answer: null,
+  sources: [],
+  error: null,
+  loading: false,
+  loaded: false,
+};
+
+/**
+ * RAG search reducer.
+ * @function ragsearch
+ * @param {Object} state Current state.
+ * @param {Object} action Action to be handled.
+ * @returns {Object} New state.
+ */
+export default function ragsearch(state = initialState, action = {}) {
+  switch (action.type) {
+    case `${RAG_SEARCH}_PENDING`:
+      return {
+        ...state,
+        loading: true,
+        loaded: false,
+        error: null,
+      };
+    case `${RAG_SEARCH}_SUCCESS`:
+      return {
+        answer: action.result?.answer || null,
+        sources: action.result?.sources || [],
+        error: action.result?.error || null,
+        loading: false,
+        loaded: true,
+      };
+    case `${RAG_SEARCH}_FAIL`:
+      return {
+        ...initialState,
+        error: action.error?.message || 'The RAG search request failed.',
+        loaded: true,
+      };
+    case RESET_RAG_SEARCH:
+      return initialState;
+    default:
+      return state;
+  }
+}

--- a/news/79.feature
+++ b/news/79.feature
@@ -1,0 +1,1 @@
+Add the foundations of the RAG AI search: LLM client (embeddings + chat), the AI search toggle with LLM endpoint configuration, structure-aware chunking, index-time chunk embedding into Solr, and full-reindex support. The feature is off unless configured. @reebalazs

--- a/solr/etc/conf/schema.xml
+++ b/solr/etc/conf/schema.xml
@@ -401,6 +401,27 @@
     <field name="content_vector" type="knn_vector_768"
       indexed="true" stored="true" multiValued="false" />
 
+    <!-- RAG chunk documents (AI search).
+    Chunks are indexed as sibling documents next to the regular content
+    documents: UID is "<parent UID>#rag-<n>", is_rag_chunk marks them,
+    parent_uid points back to the content object. Security and language
+    fields (allowedRolesAndUsers, Language, path_*) are denormalized
+    from the parent so the existing filter queries compose with {!knn}
+    vector queries as pre-filters. chunk_text is stored for prompt
+    building but NOT indexed, so chunks never match keyword searches. -->
+    <field name="is_rag_chunk" type="boolean"
+      indexed="true" stored="true" multiValued="false" />
+    <field name="parent_uid" type="string"
+      indexed="true" stored="true" multiValued="false" />
+    <field name="chunk_index" type="tint"
+      indexed="true" stored="true" multiValued="false" />
+    <field name="chunk_text" type="string"
+      indexed="false" stored="true" multiValued="false" />
+    <field name="parent_title" type="string"
+      indexed="false" stored="true" multiValued="false" />
+    <field name="rag_embedding_model" type="string"
+      indexed="true" stored="true" multiValued="false" />
+
   </fields>
 
 </schema>


### PR DESCRIPTION
Implements the foundations + indexing step of the AI search MVP (#79, internal ticket 457), targeting the `feature-ai-rag` collector branch. Two commits: the development work, and a separate `RAG: TESTING` commit that is pulled off before the final merge.

## Commit 1 — RAG foundations and indexing

- **LLM client** (`kitconcept.solr.rag`): batched embeddings with nomic task prefixes and truncation warning, OpenAI-compatible chat; endpoint paths match the kitconcept Genie server's API-key allowlist (`/ollama/api/embed` + `/api/chat/completions`), env-overridable for plain Ollama; strict timeouts, typed errors.
- **Minimal configuration**: `rag_enabled` registry toggle (profile 1004 + upgrade step), `KITCONCEPT_SOLR_LLM_URL/TOKEN` env vars; model names and tuning parameters as code defaults (`nomic-embed-text-v2-moe:latest`, `qwen3:14b`).
- **Solr schema**: chunk sibling-document fields; security/language/path denormalized so existing filter queries compose with `{!knn}` as pre-filters; chunk text stored-only (invisible to keyword search).
- **Structure-aware chunker**: ~400-token chunks (512-token model limit), sentence-boundary splitting, 10–15% overlap.
- **RagIndexProcessor** as an `IIndexQueueProcessor` utility next to collective.solr's: full rebuild on text changes, atomic metadata-only updates on workflow transitions (no re-embedding), unindex cleanup, embedding failures never fail a save; `@solr` excludes chunks via defensive fq.
- **Full-reindex support** (`@@solr-maintenance` bypasses queue processors, so `reindex_helpers.reindex` runs a dedicated RAG pass).
- **`rag_available` on the @site endpoint**: the existing `CollectiveSolrExpander` (loaded by Volto on every SSR page into redux) also carries the *effective* state of the AI search — registry toggle on **and** credentials configured — so the client knows before the first render.
  > **Decision (recorded in SPECIFICATION-79.md §8, revisitable): graceful degradation, applied consistently.** Toggle on without credentials = the feature silently reports unavailable (no hard error); AI service down = users fall back to the classic search.
- **Runtime switch without restart** (needed by end-to-end tests): `set_rag_enabled` helper, `--rag-enable`/`--rag-disable` flags on the `solr_activate_and_reindex` script (enabling before the reindex builds the chunks in the same pass), and make targets `solr-activate-and-reindex-with-rag[-clear]`.
- **Tests**: unit tests with mocked HTTP/connection; env-gated live e2e test (verified against real Solr + the kitconcept LLM server: chunks with real vectors land via the XML update path, `{!knn}` retrieves them, deletion cleans up).

## Commit 2 — RAG: TESTING (to be pulled off before the final merge)

A temporary aid so the feature can be exercised from a local site; kept as one separate commit for easy review and later removal:

- a throwaway `@rag-search` draft endpoint (rough sketch of the query pipeline, which is the next ticket),
- frontend: `ragsearch` redux action/reducer, a "Use AI" toggle and a raw debug answer area with source links in the search view,
- the toggle renders (default-on) **only when** `state.site.data['kitconcept.solr.rag_available']` is true — known via SSR before the first paint, no effects needed. An unconfigured site (like the acceptance test environment) shows the classic search completely untouched.

Design decisions and known issues are recorded in SPECIFICATION-79.md / IMPLEMENTATION-79.md.

**Missing from the PR**: the second type of chunking implementation — this will be in a separate follow-up PR.