### PR TITLE
RAG: second kind of chunking - the new Volto editor's (Plate) block storage

### DIFF
--- a/IMPLEMENTATION-79.md
+++ b/IMPLEMENTATION-79.md
@@ -189,7 +189,7 @@ remains):
 
 | Work item | Est. |
 | --- | --- |
-| Adapt chunking to the second kind | 1d |
+| ~~Adapt chunking to the second kind~~ (done 2026-07-14: Plate block storage, per-block detection, unit-tested) | 1d |
 | Shared export/import dump: same corpus drives the kitconcept.intranet demo site and this repository's CI tests | 0.5d |
 | Generation model comparison (`qwen3:14b` vs `qwen3.5:9b-q8_0` vs others) on the test questions | 0.5d |
 | Full configuration surface: registry records for model names, topK, chunk size, prompt override | 0.5d |

--- a/SPECIFICATION-79.md
+++ b/SPECIFICATION-79.md
@@ -72,7 +72,6 @@ POC-grade scope: quality tooling and tuning are deliberately deferred.
   layer is factored so it is a bounded add-on. The pure-knn MVP results
   should confirm the deferral is acceptable (earlier experiments suggested
   pure vector search may not be sufficient — see §3).
-- The second kind of chunking.
 - Full test pass (beyond minimal inline coverage accompanying the MVP PRs)
   and acceptance/CI wiring — acceptance tests are deferred until the real
   search UI is integrated, so they target that UI rather than a throwaway
@@ -302,12 +301,20 @@ All major open questions from the draft phase have been decided (team review
 | 9 | Chunk vs. document context for the prompt | Prompt with matched chunks (+ parent title/URL), cite parents |
 | 10 | Failure policy: hard error vs. graceful degradation | **Graceful degradation, applied consistently** (2026-07-13): toggle on without credentials = the feature silently reports unavailable (no error); AI service down = users fall back to the classic search instead of a hard error. The effective state is exposed to the client as `kitconcept.solr.rag_available` on the @site endpoint (registry toggle AND credentials), so the UI renders the right thing from the first paint. Recorded as revisitable: if operational practice shows silent degradation hides real misconfigurations, we can move toward hard errors. |
 
-Remaining open point:
+Resolved open point:
 
-1. **The two kinds of chunking.** Two kinds of chunking have been identified
-   for the intranet use case; details are to be clarified at implementation
-   kick-off. The MVP implements one kind; the design must stay compatible
-   with the second (post-MVP follow-up).
+1. **The two kinds of chunking** (resolved 2026-07-14): the second kind
+   is the block storage of the new Volto editor (Plate) - the rich
+   text block carries a ``value`` list of editor nodes instead of the
+   classic per-block fields. Detection is per block (the Plate block
+   ``@type``), so both kinds coexist in the same site and even on the
+   same page; the chunking logic is shared, only the reading differs.
+   Based on plone.restapi's Plate support (the authoritative
+   implementation of the storage); the provisional upstream block type
+   name may change when the new editor settles - isolated in one
+   constant. Covered by unit tests only for now: Plate pages cannot
+   yet be produced manually, e2e tests follow when the editor
+   settles.
 
 ## 9. References
 

--- a/backend/news/79.feature
+++ b/backend/news/79.feature
@@ -1,0 +1,1 @@
+Support the new Volto editor's (Plate) block storage in the RAG chunking - both kinds of pages coexist in the same site. @reebalazs

--- a/backend/src/kitconcept/solr/rag/extraction.py
+++ b/backend/src/kitconcept/solr/rag/extraction.py
@@ -1,9 +1,23 @@
 """Extraction of chunkable text segments from content objects.
 
-Reuses the block text extraction of the ``body_text_blocks`` indexer
-(``kitconcept.solr.indexers.text``) but keeps the per-block texts as
-separate segments, in layout order, so the chunker can respect the
-structural boundaries.
+Two kinds of block storage are supported, coexisting in the same site
+(detected per block):
+
+- Classic Volto blocks (slate & friends): reuses the block text
+  extraction of the ``body_text_blocks`` indexer
+  (``kitconcept.solr.indexers.text``), one segment per block, in
+  layout order.
+- Plate blocks (the rich text block of the new Volto/Seven editor):
+  the block carries a ``value`` list of editor nodes (leafs with
+  ``text``, elements with ``children``; dicts with an ``@type`` are
+  embedded Volto sub-blocks). Since the single-page editor typically
+  holds the whole page in one Plate block, one segment is emitted per
+  TOP-LEVEL element (paragraph, heading, ...), so the chunker keeps
+  its structural boundaries; embedded sub-blocks contribute their
+  segments in document order. The reading logic mirrors
+  plone.restapi's PlateTextIndexer/NestedBlocksVisitor (the
+  authoritative implementation of the Plate storage), adapted to
+  produce ordered segments instead of one flat string.
 
 MVP scope note: RAG covers block-based content plus title/description.
 The body text of binary content (File, Image) is extracted by Tika
@@ -14,6 +28,83 @@ and embedded here; supporting it is a post-MVP follow-up.
 from kitconcept.solr.indexers.text import extract_text
 from plone.restapi.behaviors import IBlocks
 from zope.globalrequest import getRequest
+
+
+# The block @type of the Plate rich text block, as currently used by
+# plone.restapi's Plate support. The name is clearly provisional
+# upstream and may change when the new editor settles - it is the
+# single decisive marker distinguishing the two kinds of chunking, so
+# keep it in this one constant. Not importable: our pinned
+# plone.restapi predates the Plate support, and even upstream main
+# hardcodes the string (no named constant). Once the feature settles
+# in a plone.restapi release we depend on, import it from there
+# instead (provided upstream exposes a constant by then).
+PLATE_BLOCK_TYPE = "__somersault__"
+
+
+def is_plate_block(block: dict) -> bool:
+    return block.get("@type") == PLATE_BLOCK_TYPE
+
+
+def plate_node_text(node) -> str:
+    """The flattened text of a Plate node (without sub-blocks).
+
+    Mirrors plone.restapi's PlateTextIndexer.extract_plate_text:
+    leafs carry ``text``, elements carry ``children``; a dict with an
+    ``@type`` is an embedded sub-block and contributes no text here
+    (it is extracted separately, as its own segment).
+    """
+    if isinstance(node, list):
+        return " ".join(plate_node_text(item) for item in node)
+    if isinstance(node, dict):
+        if "@type" in node:
+            return ""
+        texts = []
+        for key in ("text", "children"):
+            if key in node:
+                texts.append(plate_node_text(node[key]))
+        return " ".join(texts)
+    if isinstance(node, str):
+        return node.strip()
+    return ""
+
+
+def plate_embedded_blocks(node):
+    """Embedded Volto sub-blocks inside a Plate node, in document order.
+
+    The plone.restapi visitor walks these with a LIFO queue (order is
+    irrelevant for search indexing); for chunking segments the
+    document order matters, so this is a plain in-order traversal.
+    """
+    if isinstance(node, list):
+        for item in node:
+            yield from plate_embedded_blocks(item)
+    elif isinstance(node, dict):
+        if "@type" in node:
+            yield node
+        else:
+            yield from plate_embedded_blocks(node.get("children") or [])
+
+
+def extract_plate_segments(block: dict, obj, request) -> list[str]:
+    """Segments of a Plate block: one per top-level element.
+
+    The single-page editor typically stores the whole page in one
+    Plate block, so the top-level elements (paragraphs, headings, ...)
+    are the structural boundaries the chunker should see - the analog
+    of "one segment per classic block". Embedded sub-blocks are
+    extracted with the classic block extraction, in place.
+    """
+    segments = []
+    for element in block.get("value") or []:
+        text = plate_node_text(element)
+        if text and text.strip():
+            segments.append(text)
+        for embedded in plate_embedded_blocks(element):
+            embedded_text = extract_text(embedded, obj, request)
+            if embedded_text and embedded_text.strip():
+                segments.append(embedded_text)
+    return segments
 
 
 def extract_segments(obj) -> list[str]:
@@ -31,7 +122,10 @@ def extract_segments(obj) -> list[str]:
         blocks_layout = getattr(obj, "blocks_layout", None) or {}
         for block_id in blocks_layout.get("items", []):
             block = blocks.get(block_id, {})
-            text = extract_text(block, obj, request)
-            if text and text.strip():
-                segments.append(text)
+            if is_plate_block(block):
+                segments.extend(extract_plate_segments(block, obj, request))
+            else:
+                text = extract_text(block, obj, request)
+                if text and text.strip():
+                    segments.append(text)
     return segments

--- a/backend/tests/rag/test_extraction.py
+++ b/backend/tests/rag/test_extraction.py
@@ -1,0 +1,212 @@
+"""Unit tests for the text segment extraction - both kinds of chunking.
+
+The Plate structures below follow plone.restapi's Plate support (the
+authoritative implementation of the new editor's block storage):
+the block @type is __somersault__ (provisional upstream name), the
+``value`` is a list of editor nodes - elements with ``children``,
+leafs with ``text``, and dicts with an ``@type`` are embedded Volto
+sub-blocks. No end-to-end tests yet: Plate pages cannot be produced
+manually on a current site, so unit tests carry the coverage until
+the new editor settles.
+"""
+
+from kitconcept.solr.rag import extraction as extraction_module
+from kitconcept.solr.rag.extraction import extract_plate_segments
+from kitconcept.solr.rag.extraction import extract_segments
+from kitconcept.solr.rag.extraction import is_plate_block
+from kitconcept.solr.rag.extraction import PLATE_BLOCK_TYPE
+from kitconcept.solr.rag.extraction import plate_embedded_blocks
+from kitconcept.solr.rag.extraction import plate_node_text
+from unittest import mock
+
+import pytest
+
+
+def leaf(text, **marks):
+    return {"text": text, **marks}
+
+
+def element(element_type, *children):
+    return {"type": element_type, "children": list(children)}
+
+
+def plate_block(*value):
+    return {"@type": PLATE_BLOCK_TYPE, "value": list(value)}
+
+
+def make_obj(blocks, layout_items, title="", description=""):
+    obj = mock.Mock()
+    obj.Title.return_value = title
+    obj.Description.return_value = description
+    obj.blocks = blocks
+    obj.blocks_layout = {"items": layout_items}
+    return obj
+
+
+@pytest.fixture(autouse=True)
+def blocks_provided():
+    """Content objects count as IBlocks; no Zope request needed."""
+    with (
+        mock.patch.object(extraction_module.IBlocks, "providedBy", return_value=True),
+        mock.patch.object(extraction_module, "getRequest", return_value=None),
+    ):
+        yield
+
+
+class TestIsPlateBlock:
+    def test_plate_block_detected(self):
+        assert is_plate_block(plate_block()) is True
+
+    def test_classic_blocks_are_not_plate(self):
+        assert is_plate_block({"@type": "slate", "plaintext": "x"}) is False
+        assert is_plate_block({}) is False
+
+
+class TestPlateNodeText:
+    def test_leaf(self):
+        assert plate_node_text(leaf("Hello")) == "Hello"
+
+    def test_element_with_leaf_children(self):
+        node = element("p", leaf("Hello"), leaf("world"))
+        assert plate_node_text(node) == "Hello world"
+
+    def test_marked_leafs_are_plain_text(self):
+        # marks (bold, italic...) are extra keys on the leaf
+        node = element("p", leaf("Plain"), leaf("bold", bold=True))
+        assert plate_node_text(node) == "Plain bold"
+
+    def test_nested_elements(self):
+        node = element(
+            "blockquote",
+            element("p", leaf("Deeply")),
+            element("p", leaf("nested")),
+        )
+        assert plate_node_text(node) == "Deeply nested"
+
+    def test_embedded_subblock_contributes_no_text(self):
+        node = element(
+            "p",
+            leaf("Before"),
+            {"@type": "image", "searchableText": "not text content"},
+            leaf("after"),
+        )
+        assert plate_node_text(node) == "Before  after"
+
+    def test_plain_string_node(self):
+        assert plate_node_text("bare string") == "bare string"
+
+    def test_empty_and_unknown(self):
+        assert plate_node_text([]) == ""
+        assert plate_node_text({}) == ""
+        assert plate_node_text(None) == ""
+
+
+class TestPlateEmbeddedBlocks:
+    def test_in_document_order(self):
+        value = [
+            element("p", {"@type": "video", "id": "first"}),
+            element(
+                "div",
+                element("p", {"@type": "image", "id": "second"}),
+                {"@type": "teaser", "id": "third"},
+            ),
+        ]
+        found = [b["id"] for b in plate_embedded_blocks(value)]
+        assert found == ["first", "second", "third"]
+
+    def test_no_embedded_blocks(self):
+        assert list(plate_embedded_blocks([element("p", leaf("x"))])) == []
+
+
+class TestExtractPlateSegments:
+    def test_one_segment_per_top_level_element(self):
+        block = plate_block(
+            element("h2", leaf("Vacation policy")),
+            element("p", leaf("Employees get "), leaf("30 days", bold=True)),
+            element("p", leaf("Requests go through the HR portal.")),
+        )
+        segments = extract_plate_segments(block, None, None)
+        assert segments == [
+            "Vacation policy",
+            "Employees get 30 days",
+            "Requests go through the HR portal.",
+        ]
+
+    def test_empty_elements_skipped(self):
+        block = plate_block(
+            element("p", leaf("Text")),
+            element("p", leaf("   ")),
+            element("p"),
+        )
+        assert extract_plate_segments(block, None, None) == ["Text"]
+
+    def test_embedded_subblock_text_in_place(self):
+        block = plate_block(
+            element("p", leaf("Before")),
+            element(
+                "p",
+                {"@type": "custom", "searchableText": "Embedded block text"},
+            ),
+            element("p", leaf("After")),
+        )
+        segments = extract_plate_segments(block, None, None)
+        assert segments == ["Before", "Embedded block text", "After"]
+
+    def test_block_without_value(self):
+        assert extract_plate_segments({"@type": PLATE_BLOCK_TYPE}, None, None) == []
+
+
+class TestExtractSegmentsCoexistence:
+    def test_classic_page(self):
+        obj = make_obj(
+            blocks={
+                "b1": {"@type": "slate", "plaintext": "Classic slate text."},
+            },
+            layout_items=["b1"],
+            title="A title",
+            description="A description.",
+        )
+        assert extract_segments(obj) == [
+            "A title",
+            "A description.",
+            "Classic slate text.",
+        ]
+
+    def test_plate_page(self):
+        obj = make_obj(
+            blocks={
+                "b1": plate_block(
+                    element("h1", leaf("Heading")),
+                    element("p", leaf("Paragraph one.")),
+                ),
+            },
+            layout_items=["b1"],
+            title="Plate page",
+        )
+        assert extract_segments(obj) == [
+            "Plate page",
+            "Heading",
+            "Paragraph one.",
+        ]
+
+    def test_mixed_page_blocks_coexist(self):
+        # both kinds of blocks can even coexist on the same page;
+        # detection is per block
+        obj = make_obj(
+            blocks={
+                "old": {"@type": "slate", "plaintext": "Old style."},
+                "new": plate_block(element("p", leaf("New style."))),
+            },
+            layout_items=["old", "new"],
+        )
+        assert extract_segments(obj) == ["Old style.", "New style."]
+
+    def test_layout_order_respected(self):
+        obj = make_obj(
+            blocks={
+                "new": plate_block(element("p", leaf("New style."))),
+                "old": {"@type": "slate", "plaintext": "Old style."},
+            },
+            layout_items=["new", "old"],
+        )
+        assert extract_segments(obj) == ["New style.", "Old style."]


### PR DESCRIPTION
Follow-up to #87 (#79, internal ticket 457): the second kind of chunking, as announced in that PR.

The new Volto editor's (Plate) rich text block stores a `value` list of editor nodes (leafs with `text`, elements with `children`; dicts carrying an `@type` are embedded Volto sub-blocks) instead of the classic per-block fields. **The chunking logic is unchanged — only the reading differs**: detection is per block via the Plate block `@type`, so both kinds of pages coexist in the same site and even on the same page.

Notes:

- The reading mirrors **plone.restapi's Plate support** (the authoritative implementation of the storage — the PLIP itself only states the drop-in intent). The provisional upstream block type name may change when the new editor settles; it is isolated in a single constant (`PLATE_BLOCK_TYPE`).
- Adapted for chunking rather than copied: one segment per **top-level element** — the single-page editor typically holds the whole page in one Plate block, so top-level paragraphs/headings are the structural boundaries the chunker should see. Embedded sub-blocks contribute their segments **in document order** (upstream's visitor uses a LIFO queue, fine for search indexing, wrong for ordered segments).
- **Unit tests carry the coverage** (19 new tests: node text extraction incl. marks and nesting, embedded sub-block ordering, per-element segmentation, classic/Plate/mixed-page coexistence): Plate pages cannot yet be produced manually on a current site, so e2e tests follow when the editor settles.