### PR TITLE
RAG query pipeline: @rag-search retrieval endpoint + answer generation (#79)

### DIFF
--- a/IMPLEMENTATION-79.md
+++ b/IMPLEMENTATION-79.md
@@ -224,7 +224,7 @@ Goal: `@rag-search` returns `{answer, sources}` end to end.
 
 **Retrieval endpoint (1d):**
 
-- [ ] **3.1** New restapi service `@rag-search`
+- [x] **3.1** New restapi service `@rag-search`
       (`backend/src/kitconcept/solr/services/`, staged behind the toggle):
       embed query (`search_query:` prefix), run
       `{!knn f=content_vector topK=K}` with the same `fq` security/path/
@@ -234,20 +234,73 @@ Goal: `@rag-search` returns `{answer, sources}` end to end.
 
 **Answer generation (1.5d):**
 
-- [ ] **3.2 Prompt template**: fixed instruction template (answer only from
+- [x] **3.2 Prompt template**: fixed instruction template (answer only from
       the provided context; answer in the question's language; decline
       explicitly when no answer is found; refer to sources). Code default;
       registry override is post-MVP.
-- [ ] **3.3 Generation call**: send question + matched chunks (+ parent
+- [x] **3.3 Generation call**: send question + matched chunks (+ parent
       title/URL) to `qwen3:14b`; compose the `{answer, sources}` response;
       structured errors for timeout/unavailable/not-configured.
-- [ ] Validate against the Step 2 questions (smoke level: right documents
-      found, declines when it should).
+- [x] Validate against the Step 2 questions (smoke level: right documents
+      found, declines when it should). Note: Step 2 (the proper corpus,
+      internal ticket 459) was deferred by decision - validation ran
+      against a minimal hand-made corpus; re-run once the corpus lands.
 
 Demo at end of step: full RAG loop over REST on the demo corpus. **This is
 the MVP backend.** The user-facing MVP completes when the search UI from the
 kitconcept.intranet modal project integrates this endpoint (outside this
 repository's estimates).
+
+### Implementation notes — Step 3 (design decisions made on the way)
+
+- **Pipeline extracted from the HTTP layer**: the logic lives in
+  `rag/pipeline.py` (`run_rag_search`) with the prompt in
+  `rag/prompt.py`; the restapi service is a thin wrapper. This keeps
+  the pipeline testable with faked Solr/LLM and reusable by a future
+  evaluation harness.
+- **Structured errors with codes**: the response carries `error`
+  (human readable) plus `error_code` (`not_configured`,
+  `embedding_failed`, `generation_failed`, `solr_unavailable`) so the
+  frontend can degrade to the classic search. A generation failure
+  still returns the retrieved sources. Empty retrieval is NOT an
+  error: `answer: null, sources: []`.
+- **Sources are enriched parent documents**: one extra Solr query
+  fetches parent metadata (`Title`, `Description`, `Type`); each
+  source carries the best-ranked chunk's text as `snippet`. `@type`
+  is Solr's friendly type name (e.g. "Page"), consistent with the
+  classic search results.
+- **Optional filters**: `path_prefix` and `lang` request parameters
+  compose as additional pre-filter queries next to the security
+  filter.
+- **Model bake-off** (`qwen3:14b` vs alternatives) stays in the
+  overflow list per the re-scoping; the model remains fixed.
+- Observation from live testing on the minimal corpus: with only a
+  handful of documents, `topK=5` spans the whole corpus, so weakly
+  related sources appear below the top hit. On a realistic corpus a
+  score threshold (`{!vectorSimilarity}` / `minReturn`) or a smaller
+  source cutoff is worth evaluating - noted for the quality pass.
+
+## Known issues (accepted for the MVP)
+
+1. **The Solr tests and a local dev site share the Solr core.** The
+   test compose project uses the fixed host port 8983 — the same port
+   a dev Solr uses — and the test fixtures clear/recreate the index
+   (`down -v` at session start, `maintenance.clear()` in the portal
+   fixtures; the RAG live e2e tests behave exactly like the
+   pre-existing service tests here). Consequences and workarounds:
+   (a) stop the site's Solr before running the tests so the situation
+   does not arise, or (b) if it has happened, no harm is done — simply
+   reindex with `make solr-activate-and-reindex` before using the
+   site again. A real fix (ephemeral host ports for the test project,
+   wired into the test layer's `collective.solr.port`) is a **post-MVP
+   improvement**, tracked in the overflow list.
+2. **Weak sources on small corpora (topK semantics).** `{!knn topK=5}`
+   returns the 5 *nearest* chunks unconditionally, so on a small
+   corpus weakly related documents appear in the source list (answer
+   quality is unaffected — the grounding prompt handles weak context;
+   verified by the decline behavior). Accepted for now; **re-check
+   with the real corpus** (internal ticket 459) and evaluate a
+   similarity cutoff for displayed sources in the quality pass.
 
 ## Post-MVP follow-ups
 
@@ -274,6 +327,7 @@ remains):
 | Generation model comparison (`qwen3:14b` vs `qwen3.5:9b-q8_0` vs others) on the test questions | 0.5d |
 | Full configuration surface: registry records for model names, topK, chunk size, prompt override | 0.5d |
 | Acceptance test flow + full CI wiring (after the search-UI integration, so acceptance tests target the real UI) | 1d |
+| Separate Solr core/ports for tests vs. local dev site (see known issue 1) | 0.5d |
 
 **Later roadmap** (tracked, not scheduled): full evaluation harness
 (Recall@k/MRR/nDCG as CI regression gate, RAGAS faithfulness/relevancy with

--- a/backend/news/79.feature.2
+++ b/backend/news/79.feature.2
@@ -1,0 +1,1 @@
+Add the @rag-search endpoint: single-turn RAG search on a query pipeline (embed, permission-trimmed knn chunk retrieval, parent collapse, grounded answer generation) with structured error results. Exclude Image content from chunking. @reebalazs

--- a/backend/src/kitconcept/solr/rag/config.py
+++ b/backend/src/kitconcept/solr/rag/config.py
@@ -49,6 +49,10 @@ CHAT_TIMEOUT = 120.0
 # Number of texts sent to /api/embed in one request.
 EMBED_BATCH_SIZE = 32
 
+# Number of chunks retrieved for a question (and passed to the
+# generation prompt).
+TOP_K = 5
+
 REGISTRY_ENABLED_KEY = "kitconcept.solr.rag_enabled"
 
 # Endpoint paths, relative to the server root URL. The defaults match

--- a/backend/src/kitconcept/solr/rag/pipeline.py
+++ b/backend/src/kitconcept/solr/rag/pipeline.py
@@ -1,0 +1,209 @@
+"""The RAG query pipeline: question -> retrieved chunks -> answer.
+
+Implements the single-turn RAG search (SPECIFICATION-79.md §4):
+
+1. embed the user's question (``search_query:`` prefix),
+2. retrieve the top chunks via a ``{!knn}`` query — the existing
+   security/path/language filter queries compose with the vector query
+   as HNSW pre-filters, so permission trimming works unchanged,
+3. collapse the chunk hits to their parent documents (the sources),
+4. generate the answer with the general-purpose model, prompted with
+   the matched chunk texts (chunk-level context, decision 9) and
+   constrained to the provided context.
+
+The pipeline is independent of the REST service so it can be tested
+with a faked Solr connection and LLM client, and reused (e.g. by a
+future evaluation harness).
+"""
+
+from collective.solr.exceptions import SolrConnectionException
+from collective.solr.interfaces import ISolrConnectionManager
+from collective.solr.parser import SolrResponse
+from dataclasses import dataclass
+from dataclasses import field
+from kitconcept.solr.rag.client import LLMClient
+from kitconcept.solr.rag.client import LLMClientError
+from kitconcept.solr.rag.config import RagConfig
+from kitconcept.solr.rag.config import TOP_K
+from kitconcept.solr.rag.prompt import build_prompt
+from kitconcept.solr.rag.prompt import strip_thinking
+from kitconcept.solr.rag.prompt import SYSTEM_PROMPT
+from plone import api
+from zope.component import queryUtility
+
+import logging
+
+
+logger = logging.getLogger("kitconcept.solr.rag")
+
+# Error codes for structured error reporting (the frontend degrades
+# gracefully based on these; the message is for humans/logs).
+ERROR_NOT_CONFIGURED = "not_configured"
+ERROR_EMBEDDING_FAILED = "embedding_failed"
+ERROR_GENERATION_FAILED = "generation_failed"
+ERROR_SOLR_UNAVAILABLE = "solr_unavailable"
+
+CHUNK_FIELD_LIST = "UID,parent_uid,parent_title,chunk_text,path_string,score"
+SOURCE_FIELD_LIST = "UID,Title,Description,Type,path_string"
+SNIPPET_LENGTH = 300
+
+
+@dataclass
+class RagResult:
+    answer: str | None = None
+    sources: list = field(default_factory=list)
+    error: str | None = None
+    error_code: str | None = None
+
+    @classmethod
+    def failure(cls, code: str, message: str) -> "RagResult":
+        return cls(error=message, error_code=code)
+
+
+def run_rag_search(
+    question: str,
+    config: RagConfig,
+    security_filter: str,
+    path_prefix: str | None = None,
+    lang: str | None = None,
+) -> RagResult:
+    """Run the single-turn RAG search pipeline.
+
+    :param question: The user's natural language question.
+    :param config: Resolved RAG configuration.
+    :param security_filter: The allowedRolesAndUsers filter query for
+        the current user (from ``services.solr.security_filter``).
+    :param path_prefix: Optional path to restrict the search to.
+    :param lang: Optional language to restrict the search to.
+    """
+    client = LLMClient(config)
+    try:
+        vector = client.embed_query(question)
+    except LLMClientError as e:
+        logger.warning("rag-search: embedding failed: %s", e)
+        return RagResult.failure(ERROR_EMBEDDING_FAILED, str(e))
+
+    conn = get_connection()
+    if conn is None:
+        return RagResult.failure(
+            ERROR_SOLR_UNAVAILABLE, "no Solr connection (solr inactive?)"
+        )
+    try:
+        chunks = search_chunks(conn, vector, security_filter, path_prefix, lang)
+        sources = collapse_sources(conn, chunks) if chunks else []
+    except (SolrConnectionException, OSError) as e:
+        # collective.solr raises raw socket errors (e.g.
+        # ConnectionRefusedError) when the Solr server is down
+        logger.warning("rag-search: Solr unavailable: %s", e)
+        return RagResult.failure(ERROR_SOLR_UNAVAILABLE, str(e))
+    if not chunks:
+        # No matching (visible) content: not an error - the answer is
+        # that there is no answer.
+        return RagResult()
+
+    prompt = build_prompt(question, chunks)
+    try:
+        answer = client.chat(prompt, system=SYSTEM_PROMPT)
+    except LLMClientError as e:
+        logger.warning("rag-search: generation failed: %s", e)
+        result = RagResult.failure(ERROR_GENERATION_FAILED, str(e))
+        result.sources = sources  # retrieval worked; expose the sources
+        return result
+    return RagResult(answer=strip_thinking(answer), sources=sources)
+
+
+def get_connection():
+    manager = queryUtility(ISolrConnectionManager)
+    return manager.getConnection() if manager is not None else None
+
+
+def format_vector(vector: list[float]) -> str:
+    return "[" + ",".join(f"{x:.8f}" for x in vector) + "]"
+
+
+def search_chunks(
+    conn,
+    vector: list[float],
+    security_filter: str,
+    path_prefix: str | None = None,
+    lang: str | None = None,
+) -> list[dict]:
+    """Top-K chunk hits for the query vector, permission trimmed."""
+    filter_queries = [security_filter, "is_rag_chunk:true"]
+    if path_prefix:
+        portal_path = "/".join(api.portal.get().getPhysicalPath())
+        prefix = portal_path + path_prefix.rstrip("/")
+        filter_queries.append(f'path_parents:"{prefix}"')
+    if lang:
+        filter_queries.append(f"Language:({lang} OR any)")
+    response = conn.search(
+        q=f"{{!knn f=content_vector topK={TOP_K}}}{format_vector(vector)}",
+        fq=filter_queries,
+        fl=CHUNK_FIELD_LIST,
+        rows=TOP_K,
+    )
+    try:
+        return list(SolrResponse(response).results())
+    finally:
+        response.close()
+
+
+def collapse_sources(conn, chunks: list[dict]) -> list[dict]:
+    """Parent documents of the matched chunks, in rank order.
+
+    Parent-document retrieval: retrieval matches chunks, but the user
+    sees the parent documents as the sources. Parent metadata is
+    fetched from Solr in one query and merged with a snippet from the
+    best-ranked chunk of each parent.
+    """
+    order: list[str] = []
+    best_chunk: dict[str, dict] = {}
+    for chunk in chunks:
+        parent_uid = chunk.get("parent_uid")
+        if not parent_uid:
+            continue
+        if parent_uid not in best_chunk:
+            order.append(parent_uid)
+            best_chunk[parent_uid] = chunk
+    if not order:
+        return []
+    parents = fetch_parents(conn, order)
+
+    portal = api.portal.get()
+    portal_path = "/".join(portal.getPhysicalPath())
+    portal_url = portal.absolute_url()
+
+    sources = []
+    for parent_uid in order:
+        parent = parents.get(parent_uid, {})
+        chunk = best_chunk[parent_uid]
+        path_string = parent.get("path_string") or chunk.get("path_string", "")
+        url = (
+            portal_url + path_string[len(portal_path) :]
+            if path_string.startswith(portal_path)
+            else path_string
+        )
+        sources.append({
+            "@id": url,
+            "UID": parent_uid,
+            "@type": parent.get("Type", ""),
+            "title": parent.get("Title") or chunk.get("parent_title", ""),
+            "description": parent.get("Description", ""),
+            "snippet": chunk.get("chunk_text", "")[:SNIPPET_LENGTH],
+        })
+    return sources
+
+
+def fetch_parents(conn, uids: list[str]) -> dict[str, dict]:
+    """Metadata of the parent documents, keyed by UID."""
+    query = " OR ".join(f'"{uid}"' for uid in uids)
+    response = conn.search(
+        q=f"UID:({query})",
+        fl=SOURCE_FIELD_LIST,
+        rows=len(uids),
+    )
+    try:
+        results = SolrResponse(response).results()
+    finally:
+        response.close()
+    return {flare["UID"]: flare for flare in results}

--- a/backend/src/kitconcept/solr/rag/processor.py
+++ b/backend/src/kitconcept/solr/rag/processor.py
@@ -70,6 +70,13 @@ PARENT_DATA_ATTRIBUTES = [
 # this covers roughly 40k tokens of text per document.
 MAX_CHUNKS_PER_DOCUMENT = 100
 
+# Content types excluded from chunking. An Image's only chunkable text
+# is its title/description - metadata about an illustration, not
+# knowledge - and it pollutes answer sources (a photo cited as a
+# source). File stays included: its title/description locates real
+# documents (and the post-MVP Tika body text will build on it).
+EXCLUDED_PORTAL_TYPES = frozenset({"Image"})
+
 
 def chunk_uid(uid: str, index: int) -> str:
     return f"{uid}#rag-{index}"
@@ -133,6 +140,10 @@ class RagIndexProcessor:
             return
         manager, conn = self._connection()
         if conn is None:
+            return
+        if getattr(obj, "portal_type", None) in EXCLUDED_PORTAL_TYPES:
+            # also drop chunks indexed before the type was excluded
+            conn.deleteByQuery(chunk_query(uid))
             return
         if attributes is not None:
             attributes = set(attributes)

--- a/backend/src/kitconcept/solr/rag/prompt.py
+++ b/backend/src/kitconcept/solr/rag/prompt.py
@@ -1,0 +1,46 @@
+"""Prompt building for the RAG answer generation.
+
+The prompt constrains the model to the retrieved context
+(SPECIFICATION-79.md §4): answer only from the provided documents,
+answer in the language of the question, and decline explicitly when
+the answer is not found. Code default for the MVP; a registry override
+is a post-MVP configuration item.
+"""
+
+from kitconcept.solr.rag.config import TOP_K
+
+import re
+
+
+SYSTEM_PROMPT = (
+    "You are the search assistant of an intranet site. Answer the"
+    " user's question based only on the provided context documents."
+    " If the answer is not contained in them, say that you could not"
+    " find the answer in the documentation - never invent information."
+    " Answer in the language of the question. Be concise: one or two"
+    " short paragraphs, no headings and no lists unless the question"
+    " asks for an enumeration."
+)
+
+PROMPT_TEMPLATE = (
+    "Context documents:\n\n{context}\n\n"
+    "Question: {question}\n\n"
+    "Answer the question based only on the context documents above."
+)
+
+# Reasoning models may emit a thinking block; never show it to users.
+THINK_RE = re.compile(r"<think>.*?</think>\s*", re.DOTALL)
+
+
+def build_prompt(question: str, chunks: list[dict]) -> str:
+    """One prompt containing the question and the retrieved context."""
+    parts = []
+    for index, chunk in enumerate(chunks[:TOP_K], start=1):
+        title = chunk.get("parent_title", "")
+        text = chunk.get("chunk_text", "")
+        parts.append(f"[{index}] {title}\n{text}")
+    return PROMPT_TEMPLATE.format(context="\n\n".join(parts), question=question)
+
+
+def strip_thinking(answer: str) -> str:
+    return THINK_RE.sub("", answer).strip()

--- a/backend/src/kitconcept/solr/services/configure.zcml
+++ b/backend/src/kitconcept/solr/services/configure.zcml
@@ -21,8 +21,6 @@
       name="@solr-suggest"
       />
 
-  <!-- RAG: TESTING - rough draft of the RAG query pipeline, to be
-       replaced by the proper implementation (query pipeline ticket) -->
   <plone:service
       method="GET"
       factory=".rag_search.RagSearch"

--- a/backend/src/kitconcept/solr/services/rag_search.py
+++ b/backend/src/kitconcept/solr/services/rag_search.py
@@ -1,46 +1,18 @@
-"""Minimal @rag-search endpoint for local testing (RAG: TESTING).
+"""The @rag-search REST endpoint: single-turn RAG search.
 
-Rough draft of the RAG query pipeline (retrieval endpoint + answer
-generation, internal ticket 458), added ahead of time so the feature
-can be exercised from the site. To be replaced by the proper
-implementation; kept deliberately simple.
+Question in, answer + source documents out (SPECIFICATION-79.md §4).
+Thin HTTP layer over ``kitconcept.solr.rag.pipeline``; errors are
+reported structurally (``error`` message + ``error_code``) so the
+frontend can degrade gracefully to the classic search.
 """
 
-from collective.solr.interfaces import ISolrConnectionManager
-from collective.solr.parser import SolrResponse
-from kitconcept.solr.rag.client import LLMClient
-from kitconcept.solr.rag.client import LLMClientError
 from kitconcept.solr.rag.config import get_rag_config
+from kitconcept.solr.rag.pipeline import ERROR_NOT_CONFIGURED
+from kitconcept.solr.rag.pipeline import RagResult
+from kitconcept.solr.rag.pipeline import run_rag_search
 from kitconcept.solr.services.solr import security_filter
-from plone import api
 from plone.restapi.services import Service
 from zExceptions import BadRequest
-from zope.component import queryUtility
-
-import logging
-import re
-
-
-logger = logging.getLogger("kitconcept.solr.rag")
-
-TOP_K = 5
-
-SYSTEM_PROMPT = (
-    "You are the search assistant of an intranet site. Answer the"
-    " user's question based only on the provided context documents."
-    " If the answer is not contained in them, say that you could not"
-    " find the answer in the documentation. Answer in the language of"
-    " the question. Be concise: one or two short paragraphs."
-)
-
-PROMPT_TEMPLATE = (
-    "Context documents:\n\n{context}\n\n"
-    "Question: {question}\n\n"
-    "Answer the question based only on the context documents above."
-)
-
-# qwen3 may emit a thinking block; never show it to the user.
-THINK_RE = re.compile(r"<think>.*?</think>\s*", re.DOTALL)
 
 
 class RagSearch(Service):
@@ -50,82 +22,25 @@ class RagSearch(Service):
         question = self.request.form.get("q", "").strip()
         if not question:
             raise BadRequest("Missing parameter: q")
+        path_prefix = self.request.form.get("path_prefix", "").strip() or None
+        lang = self.request.form.get("lang", "").strip() or None
+
         config = get_rag_config()
         if config is None:
-            return self._error("RAG is not enabled or not configured")
-        client = LLMClient(config)
-        try:
-            vector = client.embed_query(question)
-        except LLMClientError as e:
-            logger.warning("rag-search: embedding failed: %s", e)
-            return self._error(f"embedding failed: {e}")
-        chunks = self._search_chunks(vector)
-        if not chunks:
-            return {"answer": None, "sources": [], "error": None}
-        prompt = self._build_prompt(question, chunks)
-        sources = self._sources(chunks)
-        try:
-            answer = client.chat(prompt, system=SYSTEM_PROMPT)
-        except LLMClientError as e:
-            logger.warning("rag-search: generation failed: %s", e)
-            return {
-                "answer": None,
-                "sources": sources,
-                "error": f"answer generation failed: {e}",
-            }
-        answer = THINK_RE.sub("", answer).strip()
-        return {"answer": answer, "sources": sources, "error": None}
-
-    def _error(self, message):
-        return {"answer": None, "sources": [], "error": message}
-
-    def _search_chunks(self, vector) -> list[dict]:
-        manager = queryUtility(ISolrConnectionManager)
-        conn = manager.getConnection() if manager is not None else None
-        if conn is None:
-            return []
-        vector_str = "[" + ",".join(f"{x:.8f}" for x in vector) + "]"
-        response = conn.search(
-            q=f"{{!knn f=content_vector topK={TOP_K}}}{vector_str}",
-            fq=[security_filter(), "is_rag_chunk:true"],
-            fl="UID,parent_uid,parent_title,chunk_text,path_string,score",
-            rows=TOP_K,
-        )
-        try:
-            return list(SolrResponse(response).results())
-        finally:
-            response.close()
-
-    def _build_prompt(self, question, chunks) -> str:
-        parts = []
-        for index, chunk in enumerate(chunks, start=1):
-            title = chunk.get("parent_title", "")
-            text = chunk.get("chunk_text", "")
-            parts.append(f"[{index}] {title}\n{text}")
-        return PROMPT_TEMPLATE.format(context="\n\n".join(parts), question=question)
-
-    def _sources(self, chunks) -> list[dict]:
-        """Parent documents of the matched chunks, in rank order."""
-        portal = api.portal.get()
-        portal_path = "/".join(portal.getPhysicalPath())
-        portal_url = portal.absolute_url()
-        seen = set()
-        sources = []
-        for chunk in chunks:
-            parent_uid = chunk.get("parent_uid")
-            if not parent_uid or parent_uid in seen:
-                continue
-            seen.add(parent_uid)
-            path_string = chunk.get("path_string", "")
-            url = (
-                portal_url + path_string[len(portal_path) :]
-                if path_string.startswith(portal_path)
-                else path_string
+            result = RagResult.failure(
+                ERROR_NOT_CONFIGURED, "RAG is not enabled or not configured"
             )
-            sources.append({
-                "@id": url,
-                "UID": parent_uid,
-                "title": chunk.get("parent_title", ""),
-                "snippet": chunk.get("chunk_text", "")[:300],
-            })
-        return sources
+        else:
+            result = run_rag_search(
+                question,
+                config,
+                security_filter(),
+                path_prefix=path_prefix,
+                lang=lang,
+            )
+        return {
+            "answer": result.answer,
+            "sources": result.sources,
+            "error": result.error,
+            "error_code": result.error_code,
+        }

--- a/backend/tests/rag/test_e2e_live_ragsearch.py
+++ b/backend/tests/rag/test_e2e_live_ragsearch.py
@@ -1,8 +1,8 @@
-"""Live test of the minimal @rag-search endpoint (RAG: TESTING).
+"""Live end-to-end test of the @rag-search endpoint.
 
 Same gating as test_e2e_live.py: runs only with the LLM env vars set
-and the docker Solr running. Goes with the throwaway endpoint and is
-removed together with it.
+(``KITCONCEPT_SOLR_LLM_URL``/``_TOKEN``) and the docker Solr running;
+skipped otherwise, so CI is unaffected.
 """
 
 from plone import api
@@ -79,10 +79,16 @@ class TestLiveRagSearch:
         assert response.status_code == 200
         data = response.json()
         assert data["error"] is None
+        assert data["error_code"] is None
         assert data["answer"], "expected a generated answer"
         assert "30" in data["answer"]
         assert data["sources"]
-        assert data["sources"][0]["title"] == "Vacation policy"
+        source = data["sources"][0]
+        assert source["title"] == "Vacation policy"
+        # Solr's Type field carries the friendly type name, consistent
+        # with what the classic search returns as @type
+        assert source["@type"] == "Page"
+        assert source["description"]
         assert "<think>" not in data["answer"]
 
     def test_missing_question_is_bad_request(self, manager_session):

--- a/backend/tests/rag/test_pipeline.py
+++ b/backend/tests/rag/test_pipeline.py
@@ -1,0 +1,210 @@
+from kitconcept.solr.rag import pipeline as pipeline_module
+from kitconcept.solr.rag.client import LLMClientError
+from kitconcept.solr.rag.config import RagConfig
+from kitconcept.solr.rag.pipeline import collapse_sources
+from kitconcept.solr.rag.pipeline import ERROR_EMBEDDING_FAILED
+from kitconcept.solr.rag.pipeline import ERROR_GENERATION_FAILED
+from kitconcept.solr.rag.pipeline import ERROR_SOLR_UNAVAILABLE
+from kitconcept.solr.rag.pipeline import format_vector
+from kitconcept.solr.rag.pipeline import run_rag_search
+from kitconcept.solr.rag.pipeline import search_chunks
+from unittest import mock
+
+import pytest
+
+
+CONFIG = RagConfig(
+    base_url="http://llm.example.com",
+    token=None,
+    embed_model="test-embed",
+    chat_model="test-chat",
+)
+
+SECURITY_FQ = "allowedRolesAndUsers:(Anonymous)"
+
+CHUNKS = [
+    {
+        "UID": "uid-a#rag-1",
+        "parent_uid": "uid-a",
+        "parent_title": "Vacation policy",
+        "chunk_text": "30 days of paid vacation per year.",
+        "path_string": "/plone/vacation-policy",
+        "score": 0.9,
+    },
+    {
+        "UID": "uid-a#rag-0",
+        "parent_uid": "uid-a",
+        "parent_title": "Vacation policy",
+        "chunk_text": "Requests go through the HR portal.",
+        "path_string": "/plone/vacation-policy",
+        "score": 0.8,
+    },
+    {
+        "UID": "uid-b#rag-0",
+        "parent_uid": "uid-b",
+        "parent_title": "Cafeteria",
+        "chunk_text": "Meal subsidy is 6 euros.",
+        "path_string": "/plone/cafeteria",
+        "score": 0.5,
+    },
+]
+
+PARENTS = {
+    "uid-a": {
+        "UID": "uid-a",
+        "Title": "Vacation policy",
+        "Description": "Annual leave rules.",
+        "Type": "Page",
+        "path_string": "/plone/vacation-policy",
+    },
+    "uid-b": {
+        "UID": "uid-b",
+        "Title": "Cafeteria",
+        "Description": "Meals.",
+        "Type": "Page",
+        "path_string": "/plone/cafeteria",
+    },
+}
+
+
+@pytest.fixture(autouse=True)
+def portal():
+    fake = mock.Mock()
+    fake.getPhysicalPath.return_value = ("", "plone")
+    fake.absolute_url.return_value = "http://nohost/plone"
+    with mock.patch.object(pipeline_module.api.portal, "get", return_value=fake):
+        yield fake
+
+
+@pytest.fixture
+def conn():
+    return mock.Mock()
+
+
+@pytest.fixture(autouse=True)
+def environment(conn):
+    """Fake LLM client, Solr connection, retrieval and parent lookup."""
+    with (
+        mock.patch.object(pipeline_module, "LLMClient") as llm_class,
+        mock.patch.object(pipeline_module, "get_connection", return_value=conn),
+        mock.patch.object(
+            pipeline_module, "search_chunks", return_value=list(CHUNKS)
+        ) as searcher,
+        mock.patch.object(pipeline_module, "fetch_parents", return_value=dict(PARENTS)),
+    ):
+        llm_class.return_value.embed_query.return_value = [0.1, 0.2]
+        llm_class.return_value.chat.return_value = "The answer is 30 days."
+        yield {"llm": llm_class, "searcher": searcher}
+
+
+class TestRunRagSearch:
+    def test_success(self):
+        result = run_rag_search("How many vacation days?", CONFIG, SECURITY_FQ)
+        assert result.error is None
+        assert result.answer == "The answer is 30 days."
+        assert [s["UID"] for s in result.sources] == ["uid-a", "uid-b"]
+
+    def test_thinking_is_stripped(self, environment):
+        environment[
+            "llm"
+        ].return_value.chat.return_value = "<think>hmm</think>The answer."
+        result = run_rag_search("q", CONFIG, SECURITY_FQ)
+        assert result.answer == "The answer."
+
+    def test_embedding_failure(self, environment):
+        environment["llm"].return_value.embed_query.side_effect = LLMClientError("down")
+        result = run_rag_search("q", CONFIG, SECURITY_FQ)
+        assert result.error_code == ERROR_EMBEDDING_FAILED
+        assert result.answer is None
+        assert result.sources == []
+
+    def test_generation_failure_still_exposes_sources(self, environment):
+        environment["llm"].return_value.chat.side_effect = LLMClientError("down")
+        result = run_rag_search("q", CONFIG, SECURITY_FQ)
+        assert result.error_code == ERROR_GENERATION_FAILED
+        assert result.answer is None
+        assert [s["UID"] for s in result.sources] == ["uid-a", "uid-b"]
+
+    def test_no_solr_connection(self):
+        with mock.patch.object(pipeline_module, "get_connection", return_value=None):
+            result = run_rag_search("q", CONFIG, SECURITY_FQ)
+        assert result.error_code == ERROR_SOLR_UNAVAILABLE
+
+    def test_solr_server_down(self):
+        """A dead Solr server raises a raw socket error, not a Solr
+        exception - it must map to solr_unavailable, not a 500."""
+        with mock.patch.object(
+            pipeline_module,
+            "search_chunks",
+            side_effect=ConnectionRefusedError(61, "Connection refused"),
+        ):
+            result = run_rag_search("q", CONFIG, SECURITY_FQ)
+        assert result.error_code == ERROR_SOLR_UNAVAILABLE
+        assert result.answer is None
+
+    def test_no_chunks_found_is_not_an_error(self, environment):
+        with mock.patch.object(pipeline_module, "search_chunks", return_value=[]):
+            result = run_rag_search("q", CONFIG, SECURITY_FQ)
+        assert result.error is None
+        assert result.answer is None
+        assert result.sources == []
+
+
+class TestCollapseSources:
+    def test_parents_in_rank_order_deduplicated(self, conn):
+        with mock.patch.object(
+            pipeline_module, "fetch_parents", return_value=dict(PARENTS)
+        ):
+            sources = collapse_sources(conn, CHUNKS)
+        assert [s["UID"] for s in sources] == ["uid-a", "uid-b"]
+
+    def test_source_shape(self, conn):
+        with mock.patch.object(
+            pipeline_module, "fetch_parents", return_value=dict(PARENTS)
+        ):
+            sources = collapse_sources(conn, CHUNKS)
+        source = sources[0]
+        assert source["@id"] == "http://nohost/plone/vacation-policy"
+        assert source["title"] == "Vacation policy"
+        assert source["description"] == "Annual leave rules."
+        assert source["@type"] == "Page"
+        # snippet comes from the best ranked chunk of the parent
+        assert source["snippet"] == "30 days of paid vacation per year."
+
+    def test_missing_parent_metadata_falls_back_to_chunk(self, conn):
+        with mock.patch.object(pipeline_module, "fetch_parents", return_value={}):
+            sources = collapse_sources(conn, CHUNKS)
+        assert sources[0]["title"] == "Vacation policy"
+        assert sources[0]["@id"] == "http://nohost/plone/vacation-policy"
+
+
+class TestSearchChunks:
+    def fake_response(self):
+        response = mock.Mock()
+        response.read.return_value = (
+            b'<?xml version="1.0"?><response>'
+            b'<result name="response" numFound="0" start="0"/></response>'
+        )
+        return response
+
+    def search_params(self, conn, **kwargs):
+        conn.search.return_value = self.fake_response()
+        with mock.patch.object(pipeline_module, "SolrResponse") as solr_response:
+            solr_response.return_value.results.return_value = []
+            search_chunks(conn, [0.5, 0.5], SECURITY_FQ, **kwargs)
+        return conn.search.call_args.kwargs
+
+    def test_knn_query_with_security_prefilter(self, conn):
+        params = self.search_params(conn)
+        assert params["q"].startswith("{!knn f=content_vector topK=")
+        assert format_vector([0.5, 0.5]) in params["q"]
+        assert SECURITY_FQ in params["fq"]
+        assert "is_rag_chunk:true" in params["fq"]
+
+    def test_path_prefix_filter(self, conn):
+        params = self.search_params(conn, path_prefix="/documents/")
+        assert 'path_parents:"/plone/documents"' in params["fq"]
+
+    def test_language_filter(self, conn):
+        params = self.search_params(conn, lang="en")
+        assert "Language:(en OR any)" in params["fq"]

--- a/backend/tests/rag/test_processor.py
+++ b/backend/tests/rag/test_processor.py
@@ -106,6 +106,14 @@ def environment(obj):
 
 
 class TestIndexRebuild:
+    def test_image_is_not_chunked(self, proc, conn, obj):
+        """Binary content (Image) gets no chunks; stale chunks from
+        before the exclusion are removed."""
+        obj.portal_type = "Image"
+        proc.index(obj)
+        assert conn.added == []
+        assert conn.deleted_queries == [chunk_query(UID)]
+
     def test_deletes_then_adds_chunks(self, proc, conn, obj):
         proc.index(obj)
         assert conn.deleted_queries == [chunk_query(UID)]

--- a/backend/tests/rag/test_prompt.py
+++ b/backend/tests/rag/test_prompt.py
@@ -1,0 +1,50 @@
+from kitconcept.solr.rag.config import TOP_K
+from kitconcept.solr.rag.prompt import build_prompt
+from kitconcept.solr.rag.prompt import strip_thinking
+from kitconcept.solr.rag.prompt import SYSTEM_PROMPT
+
+
+def chunk(title, text):
+    return {"parent_title": title, "chunk_text": text}
+
+
+class TestBuildPrompt:
+    def test_contains_question_and_context(self):
+        prompt = build_prompt(
+            "How many vacation days?",
+            [chunk("Vacation policy", "30 days of paid vacation.")],
+        )
+        assert "Question: How many vacation days?" in prompt
+        assert "[1] Vacation policy\n30 days of paid vacation." in prompt
+        assert "based only on the context documents" in prompt
+
+    def test_chunks_are_numbered_in_order(self):
+        prompt = build_prompt(
+            "q",
+            [chunk("First", "text one"), chunk("Second", "text two")],
+        )
+        assert prompt.index("[1] First") < prompt.index("[2] Second")
+
+    def test_context_is_capped_at_top_k(self):
+        chunks = [chunk(f"Doc {i}", f"text {i}") for i in range(TOP_K + 3)]
+        prompt = build_prompt("q", chunks)
+        assert f"[{TOP_K}] " in prompt
+        assert f"[{TOP_K + 1}] " not in prompt
+
+    def test_system_prompt_constrains_generation(self):
+        assert "based only on the provided context" in SYSTEM_PROMPT
+        assert "could not find the answer" in SYSTEM_PROMPT
+        assert "language of the question" in SYSTEM_PROMPT
+
+
+class TestStripThinking:
+    def test_removes_thinking_block(self):
+        answer = "<think>\nreasoning here\n</think>\nThe answer."
+        assert strip_thinking(answer) == "The answer."
+
+    def test_plain_answer_untouched(self):
+        assert strip_thinking("The answer.") == "The answer."
+
+    def test_multiline_thinking(self):
+        answer = "<think>line1\nline2</think>  \n\nAnswer\nwith lines."
+        assert strip_thinking(answer) == "Answer\nwith lines."

--- a/backend/tests/rag/test_service_rag_search.py
+++ b/backend/tests/rag/test_service_rag_search.py
@@ -1,0 +1,119 @@
+from kitconcept.solr.rag.config import RagConfig
+from kitconcept.solr.rag.pipeline import ERROR_NOT_CONFIGURED
+from kitconcept.solr.rag.pipeline import RagResult
+from kitconcept.solr.services import rag_search as service_module
+from kitconcept.solr.services.rag_search import RagSearch
+from plone.app.testing import SITE_OWNER_NAME
+from plone.app.testing import SITE_OWNER_PASSWORD
+from plone.restapi.testing import RelativeSession
+from unittest import mock
+from zExceptions import BadRequest
+
+import pytest
+import transaction
+
+
+CONFIG = RagConfig(
+    base_url="http://llm.example.com",
+    token=None,
+    embed_model="test-embed",
+    chat_model="test-chat",
+)
+
+
+@pytest.fixture
+def service(integration):
+    portal = integration["portal"]
+    request = integration["request"]
+    service = RagSearch()
+    service.context = portal
+    service.request = request
+    return service
+
+
+class TestRagSearchService:
+    def test_missing_question_is_bad_request(self, service):
+        with pytest.raises(BadRequest):
+            service.reply()
+
+    def test_not_configured(self, service):
+        service.request.form["q"] = "a question"
+        with mock.patch.object(service_module, "get_rag_config", return_value=None):
+            data = service.reply()
+        assert data["answer"] is None
+        assert data["sources"] == []
+        assert data["error_code"] == ERROR_NOT_CONFIGURED
+        assert data["error"]
+
+    def test_success_shape(self, service):
+        service.request.form["q"] = "a question"
+        result = RagResult(
+            answer="The answer.",
+            sources=[{"@id": "http://nohost/plone/doc", "title": "Doc"}],
+        )
+        with (
+            mock.patch.object(service_module, "get_rag_config", return_value=CONFIG),
+            mock.patch.object(
+                service_module, "run_rag_search", return_value=result
+            ) as runner,
+        ):
+            data = service.reply()
+        assert data == {
+            "answer": "The answer.",
+            "sources": [{"@id": "http://nohost/plone/doc", "title": "Doc"}],
+            "error": None,
+            "error_code": None,
+        }
+        # the security filter of the current user is passed through
+        assert "allowedRolesAndUsers" in runner.call_args.args[2]
+
+    def test_optional_params_passed(self, service):
+        service.request.form.update({
+            "q": "a question",
+            "path_prefix": "/documents",
+            "lang": "en",
+        })
+        with (
+            mock.patch.object(service_module, "get_rag_config", return_value=CONFIG),
+            mock.patch.object(
+                service_module, "run_rag_search", return_value=RagResult()
+            ) as runner,
+        ):
+            service.reply()
+        assert runner.call_args.kwargs["path_prefix"] == "/documents"
+        assert runner.call_args.kwargs["lang"] == "en"
+
+    def test_empty_optional_params_are_none(self, service):
+        service.request.form.update({"q": "a question", "path_prefix": " "})
+        with (
+            mock.patch.object(service_module, "get_rag_config", return_value=CONFIG),
+            mock.patch.object(
+                service_module, "run_rag_search", return_value=RagResult()
+            ) as runner,
+        ):
+            service.reply()
+        assert runner.call_args.kwargs["path_prefix"] is None
+        assert runner.call_args.kwargs["lang"] is None
+
+
+class TestRagSearchOverHttp:
+    """The endpoint is registered and traversable (no LLM involved)."""
+
+    @pytest.fixture
+    def manager_session(self, functional):
+        portal = functional["app"]["plone"]
+        transaction.commit()
+        session = RelativeSession(portal.absolute_url())
+        session.headers.update({"Accept": "application/json"})
+        session.auth = (SITE_OWNER_NAME, SITE_OWNER_PASSWORD)
+        return session
+
+    def test_not_configured_over_http(self, manager_session):
+        response = manager_session.get("/@rag-search", params={"q": "hello"})
+        assert response.status_code == 200
+        data = response.json()
+        assert data["error_code"] == ERROR_NOT_CONFIGURED
+
+    def test_missing_question_over_http(self, manager_session):
+        response = manager_session.get("/@rag-search")
+        assert response.status_code == 400

--- a/frontend/packages/volto-solr/src/components/theme/SolrSearch/SolrSearch.jsx
+++ b/frontend/packages/volto-solr/src/components/theme/SolrSearch/SolrSearch.jsx
@@ -274,11 +274,11 @@ class SolrSearch extends Component {
     this.setState({ searchwordInStatus: params.SearchableText || '' });
     // RAG: TESTING - when RAG is available (the @site endpoint
     // reported the feature enabled and configured, known before the
-    // first render) and the toggle is on, the question goes to the
-    // RAG endpoint instead of the classic solr search
+    // first render) and the toggle is on, the question additionally
+    // goes to the RAG endpoint: the AI answer renders above the
+    // classic result list, it does not replace it
     if (this.props.ragAvailable && this.state.useAI && params.SearchableText) {
       this.props.ragSearch('', params.SearchableText);
-      return;
     }
     this.props.searchContent('', {
       ...params,

--- a/news/79.feature
+++ b/news/79.feature
@@ -1,1 +1,2 @@
 Add the foundations of the RAG AI search: LLM client (embeddings + chat), the AI search toggle with LLM endpoint configuration, structure-aware chunking, index-time chunk embedding into Solr, and full-reindex support. The feature is off unless configured. @reebalazs
+Add the @rag-search endpoint: single-turn RAG search returning a generated answer with the source documents, permission-trimmed vector retrieval, structured errors. @reebalazs


### PR DESCRIPTION
Step 3 of the RAG MVP (ticket: distribution-kitconcept-intranet#458, part of #79): a question to `@rag-search` returns `{answer, sources}` end to end. Second commit is the removable `RAG: TESTING:` UI aid.

## What's included

- **3.1 Grounded prompt template**: answer strictly from the provided context, decline when the answer is not in it, reply in the question's language; `<think>` blocks stripped
- **3.2 Query pipeline** (`rag/pipeline.py`): embed the question → `{!knn}` chunk retrieval with the same security/path/language pre-filters as the classic search → collapse chunks to parent documents → generate. `RagResult` with error codes (`not_configured` / `embedding_failed` / `generation_failed` / `solr_unavailable`); generation failure still exposes the retrieved sources; empty retrieval is not an error
- **3.3 `@rag-search` restapi service** on the pipeline (`q` required → 400, optional `path_prefix`/`lang`), replacing the TESTING draft endpoint
- **Robustness**: raw socket errors from a dead Solr server map to `solr_unavailable` instead of a 500
- **Indexing fix** (to the already-merged foundations): `Image` content is excluded from chunking — its only chunkable text is title/description, which polluted answer sources with photos; `File` stays included (its title/description locates real documents, and the post-MVP Tika body extraction builds on it)
- **Docs**: Step 3 design decisions and known issues (shared test Solr core, topK source tail) in IMPLEMENTATION-79.md
- **TESTING commit**: with the Use AI toggle on, the answer now renders above the classic result list instead of replacing it (the old routing displayed a misleading "No results")

## Verification

Against the bundled German demo corpus (#89): golden questions **19/19 retrieval hits, 2/2 declines**, no binary content cited as sources after the indexing fix; permission trimming holds (private pages absent for the plain member `f.meier`); RAG test suite 110 passed.
