### PR TITLE
RAG: record the AI-tab presentation design replacing the AI toggle (#79)

### DIFF
--- a/IMPLEMENTATION-79.md
+++ b/IMPLEMENTATION-79.md
@@ -317,6 +317,21 @@ repository's estimates).
       integration test against the docker-compose stack with deterministic
       mock endpoints (CI needs no GPU/model).
 
+**AI presentation via tabs configuration** (decided with the team
+2026-07-23, replaces the earlier "AI search" toggle; to be elaborated
+and implemented after the UX has been seen live in kitconcept.intranet):
+
+- [ ] Google-style presentation, driven by the kitconcept.solr **tabs
+      configuration** with two per-tab flags:
+      - **"AI results"**: the tab shows only the AI answer (a dedicated
+        "AI" tab);
+      - **"AI on top"**: the tab prepends the AI answer to its classic
+        result list (used on the "All" tab).
+      Any consumer (including kitconcept.intranet) composes the
+      presentation freely from these flags. Until this lands, the
+      interim UI always shows the AI answer above the classic results
+      (no toggle).
+
 **Step P2 — Overflow tasks** (first candidates after that, or if time
 remains):
 

--- a/SPECIFICATION-79.md
+++ b/SPECIFICATION-79.md
@@ -253,9 +253,19 @@ modal (command-palette pattern) is being designed and implemented separately
 in the kitconcept.intranet project; the RAG feature integrates into it before
 the MVP ships. Decisions that affect this repository:
 
-- There will be an **"AI search" toggle in the search UI** — RAG does not
-  unconditionally replace the normal search; the classic `@solr` search
-  remains fully functional and unchanged.
+- ~~There will be an **"AI search" toggle in the search UI**~~ **Revised
+  (team discussion, 2026-07-23): no user-facing AI toggle.** The
+  presentation follows the Google pattern instead: an **"AI" tab** shows
+  the AI result alone, and the **"All" tab** shows the AI answer on top
+  of the classic results. Planned as kitconcept.solr **tabs
+  configuration**: two per-tab flags — "AI results" (the tab shows only
+  the AI answer) and "AI on top" (the tab prepends the AI answer to its
+  result list) — so any consumer (including kitconcept.intranet)
+  composes the presentation freely. To be finalized and implemented
+  after the UX has been seen live in kitconcept.intranet; until then the
+  interim UI always shows the AI answer above the classic results.
+  Unchanged: RAG does not replace the normal search; the classic `@solr`
+  search remains fully functional.
 - During backend development, testing happens over REST (optionally a
   throwaway input box); no acceptance tests are written against interim UI.
 - The answer panel must carry a visible "AI-generated — verify against the


### PR DESCRIPTION
Docs-only: records the team decision of 2026-07-23 in SPECIFICATION-79 (§6) and IMPLEMENTATION-79 (post-MVP list) — no user-facing AI toggle; instead a Google-style presentation driven by the kitconcept.solr tabs configuration with two per-tab flags:

- **"AI results"**: the tab shows only the AI answer (a dedicated "AI" tab)
- **"AI on top"**: the tab prepends the AI answer to its classic result list (the "All" tab)

Any consumer (including kitconcept.intranet) composes the presentation from these flags. To be elaborated and implemented after the UX has been evaluated live in kitconcept.intranet; until then the interim UI always shows the AI answer above the classic results.