### PR TITLE
Fix useMemo deps growing between renders in SearchConditions (#94)

### DIFF
--- a/frontend/packages/volto-solr/news/94.bugfix
+++ b/frontend/packages/volto-solr/news/94.bugfix
@@ -1,0 +1,1 @@
+Fix React warning in SearchConditions: the useMemo dependency array grew as vocabularies loaded (spread of vocabData values); use the vocabData object itself as a constant-size dependency. @reebalazs

--- a/frontend/packages/volto-solr/src/components/theme/SolrSearch/SearchConditions.jsx
+++ b/frontend/packages/volto-solr/src/components/theme/SolrSearch/SearchConditions.jsx
@@ -147,8 +147,12 @@ export const SearchConditions = ({
           })}
         </div>
       ) : null,
-    // Use spread operator to perform a shallow equality check on the vocabData object
+    // vocabData comes from useSelector(..., shallowEqual) in useVocabs,
+    // so its identity only changes when some vocabulary's items change:
+    // it works as a single dependency. (Spreading its values here made
+    // the deps array grow as vocabularies loaded, which React warns
+    // about: the deps array size must stay constant between renders.)
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [JSON.stringify(facetFields), conditionTree, ...Object.values(vocabData)],
+    [JSON.stringify(facetFields), conditionTree, vocabData],
   );
 };


### PR DESCRIPTION
Fixes the React dev warning `The final argument passed to useMemo changed size between renders` on the search page (#94).

The deps array spread `Object.values(vocabData)`, which grows from 0 to N entries as facet vocabularies load. `vocabData` comes from `useSelector(..., shallowEqual)` in `useVocabs`, so its identity already changes exactly when some vocabulary's items change — it serves as a single constant-size dependency with identical recompute triggers (no missed updates, no per-render recomputes; react-redux reuses the previous reference when the equality function passes, in both v7 and v8 semantics).

Verified in the browser: warning gone on search page loads with facet vocabularies; all 17 SearchConditions unit tests pass.

Same fix goes to `main` in a separate PR (the bug exists on the release line too).