### PR TITLE
Fix Segment children prop-types warning for the Toolbar portal (#97)

### DIFF
--- a/frontend/packages/volto-solr/news/97.bugfix
+++ b/frontend/packages/volto-solr/news/97.bugfix
@@ -1,0 +1,1 @@
+Fix React prop-types warning on client-side navigation to the search page: the Toolbar portal is rendered as a sibling of the Segment instead of a child (prop-types does not recognize ReactPortal as a node). @reebalazs

--- a/frontend/packages/volto-solr/src/components/theme/SolrSearch/SolrSearch.jsx
+++ b/frontend/packages/volto-solr/src/components/theme/SolrSearch/SolrSearch.jsx
@@ -332,134 +332,140 @@ class SolrSearch extends Component {
       this.props.contentTypeSearchResultViews[contentType] ||
       this.props.contentTypeSearchResultDefaultView;
     return (
-      <Segment basic id="page-search" className="header-wrapper">
-        <Helmet title="Search" />
-        <Container>
-          {this.props.showSearchInput ? (
-            <div className="search-input">
-              <form className="ui form" onSubmit={this.onSubmit}>
-                <div className="field searchbox">
-                  <TranslatedInput
-                    ref={this.inputRef}
-                    placeholder={messages.TypeSearchWords}
-                    className="searchinput"
-                    value={this.state.searchword}
-                    onChange={(e) =>
-                      this.setState({ searchword: e.target.value })
-                    }
-                    onSubmit={this.onSubmit}
-                  />
-                  <Button onClick={this.onSubmit}>
-                    <FormattedMessage id="Search" defaultMessage="Search" />{' '}
-                  </Button>
-                </div>
-              </form>
-            </div>
-          ) : null}
-          {this.state.allowLocal &&
-          getPathPrefix(this.props.history.location) !== undefined ? (
-            <LocalCheckbox
-              onChange={(checked) => this.setLocal(checked)}
-              checked={this.state.local}
-            />
-          ) : null}
-          <SearchResultInfo
-            searchableText={this.state.searchwordInStatus}
-            total={this.props.total}
-          />
-          <SearchTabs
-            groupSelect={this.state.groupSelect}
-            setGroupSelect={(groupSelect) => this.setGroupSelect(groupSelect)}
-            facetGroups={this.props.facetGroups}
-          />
-          <VocabProvider>
-            <article id="content">
-              <header>
-                {this.props.total > 0 ? (
-                  <div className="sorting-bar">
-                    <SelectLayout
-                      layouts={this.props.layouts}
-                      value={this.state.layout}
-                      onChange={(value) => {
-                        this.setState({ layout: value });
-                      }}
+      <>
+        <Segment basic id="page-search" className="header-wrapper">
+          <Helmet title="Search" />
+          <Container>
+            {this.props.showSearchInput ? (
+              <div className="search-input">
+                <form className="ui form" onSubmit={this.onSubmit}>
+                  <div className="field searchbox">
+                    <TranslatedInput
+                      ref={this.inputRef}
+                      placeholder={messages.TypeSearchWords}
+                      className="searchinput"
+                      value={this.state.searchword}
+                      onChange={(e) =>
+                        this.setState({ searchword: e.target.value })
+                      }
+                      onSubmit={this.onSubmit}
                     />
-                    <SelectSorting
-                      value={this.state.sortOn}
-                      onChange={(selectedOption, order) => {
-                        this.onSortChange(selectedOption, order);
-                      }}
-                    />
+                    <Button onClick={this.onSubmit}>
+                      <FormattedMessage id="Search" defaultMessage="Search" />{' '}
+                    </Button>
                   </div>
-                ) : null}
-              </header>
-              <div className="searchContentWrapper">
-                <SearchConditions
-                  groupSelect={this.state.groupSelect}
-                  facetFields={this.props.facetFields}
-                  vocabularies={this.props.vocabularies}
-                  conditionTree={this.state.facetConditions}
-                  setConditionTree={this.setConditionTree}
-                />
-                <Dimmer active={this.props.loading} inverted>
-                  <Loader indeterminate size="small">
-                    <FormattedMessage id="loading" defaultMessage="Loading" />
-                  </Loader>
-                </Dimmer>
-                <section
-                  id="content-core"
-                  className={`layout-${this.state.layout}`}
-                >
-                  <div className="search-items">
-                    {this.props.items?.map((item, index) => (
-                      <div key={'' + index + '-' + item['@id']}>
-                        {createElement(resultTypeMapper(item['@type']), {
-                          key: item['@id'],
-                          item,
-                          layout: this.state.layout,
-                        })}
-                      </div>
-                    ))}
-                  </div>
-                  {this.props.batching &&
-                    this.props.total / settings.defaultPageSize > 1 && (
-                      <div className="search-footer">
-                        <Pagination
-                          activePage={this.state.currentPage}
-                          totalPages={Math.ceil(
-                            this.props.total / settings.defaultPageSize,
-                          )}
-                          onPageChange={this.handleQueryPaginationChange}
-                          firstItem={null}
-                          lastItem={null}
-                          prevItem={{
-                            content: (
-                              <Icon name={paginationLeftSVG} size="18px" />
-                            ),
-                            icon: true,
-                            'aria-disabled': !this.props.batching.prev,
-                            className: !this.props.batching.prev
-                              ? 'disabled'
-                              : null,
-                          }}
-                          nextItem={{
-                            content: (
-                              <Icon name={paginationRightSVG} size="18px" />
-                            ),
-                            icon: true,
-                            'aria-disabled': !this.props.batching.next,
-                            className: !this.props.batching.next
-                              ? 'disabled'
-                              : null,
-                          }}
-                        />
-                      </div>
-                    )}
-                </section>
+                </form>
               </div>
-            </article>
-          </VocabProvider>
-        </Container>
+            ) : null}
+            {this.state.allowLocal &&
+            getPathPrefix(this.props.history.location) !== undefined ? (
+              <LocalCheckbox
+                onChange={(checked) => this.setLocal(checked)}
+                checked={this.state.local}
+              />
+            ) : null}
+            <SearchResultInfo
+              searchableText={this.state.searchwordInStatus}
+              total={this.props.total}
+            />
+            <SearchTabs
+              groupSelect={this.state.groupSelect}
+              setGroupSelect={(groupSelect) => this.setGroupSelect(groupSelect)}
+              facetGroups={this.props.facetGroups}
+            />
+            <VocabProvider>
+              <article id="content">
+                <header>
+                  {this.props.total > 0 ? (
+                    <div className="sorting-bar">
+                      <SelectLayout
+                        layouts={this.props.layouts}
+                        value={this.state.layout}
+                        onChange={(value) => {
+                          this.setState({ layout: value });
+                        }}
+                      />
+                      <SelectSorting
+                        value={this.state.sortOn}
+                        onChange={(selectedOption, order) => {
+                          this.onSortChange(selectedOption, order);
+                        }}
+                      />
+                    </div>
+                  ) : null}
+                </header>
+                <div className="searchContentWrapper">
+                  <SearchConditions
+                    groupSelect={this.state.groupSelect}
+                    facetFields={this.props.facetFields}
+                    vocabularies={this.props.vocabularies}
+                    conditionTree={this.state.facetConditions}
+                    setConditionTree={this.setConditionTree}
+                  />
+                  <Dimmer active={this.props.loading} inverted>
+                    <Loader indeterminate size="small">
+                      <FormattedMessage id="loading" defaultMessage="Loading" />
+                    </Loader>
+                  </Dimmer>
+                  <section
+                    id="content-core"
+                    className={`layout-${this.state.layout}`}
+                  >
+                    <div className="search-items">
+                      {this.props.items?.map((item, index) => (
+                        <div key={'' + index + '-' + item['@id']}>
+                          {createElement(resultTypeMapper(item['@type']), {
+                            key: item['@id'],
+                            item,
+                            layout: this.state.layout,
+                          })}
+                        </div>
+                      ))}
+                    </div>
+                    {this.props.batching &&
+                      this.props.total / settings.defaultPageSize > 1 && (
+                        <div className="search-footer">
+                          <Pagination
+                            activePage={this.state.currentPage}
+                            totalPages={Math.ceil(
+                              this.props.total / settings.defaultPageSize,
+                            )}
+                            onPageChange={this.handleQueryPaginationChange}
+                            firstItem={null}
+                            lastItem={null}
+                            prevItem={{
+                              content: (
+                                <Icon name={paginationLeftSVG} size="18px" />
+                              ),
+                              icon: true,
+                              'aria-disabled': !this.props.batching.prev,
+                              className: !this.props.batching.prev
+                                ? 'disabled'
+                                : null,
+                            }}
+                            nextItem={{
+                              content: (
+                                <Icon name={paginationRightSVG} size="18px" />
+                              ),
+                              icon: true,
+                              'aria-disabled': !this.props.batching.next,
+                              className: !this.props.batching.next
+                                ? 'disabled'
+                                : null,
+                            }}
+                          />
+                        </div>
+                      )}
+                  </section>
+                </div>
+              </article>
+            </VocabProvider>
+          </Container>
+        </Segment>
+        {/* The Toolbar portal is a sibling of the Segment, not a child:
+            createPortal returns a ReactPortal, which renders fine but is
+            not recognized by the prop-types `node` checker, so Segment's
+            propTypes would warn about invalid children (#97). */}
         {this.state.isClient &&
           createPortal(
             <Toolbar
@@ -469,7 +475,7 @@ class SolrSearch extends Component {
             />,
             document.getElementById('toolbar'),
           )}
-      </Segment>
+      </>
     );
   }
 }


### PR DESCRIPTION
Fixes the React warning `Invalid prop children supplied to Segment, expected a ReactNode` on client-side navigation to the search page. Fixes #97.

`createPortal` returns a `ReactPortal` — renderable, but not recognized by the prop-types `node` checker, so Segment's propTypes flagged it. The portal now renders as a sibling of the Segment inside a fragment; behavior is unchanged (a portal renders into its DOM target regardless of tree position, and Segment provides no context or handlers the subtree would lose).

Port of #98 (feature-ai-rag) to `main`. The bulk of the diff is prettier reindentation from the fragment wrapper — **review with `git diff -w`** (7 insertions, 1 deletion).