### PR TITLE
Local search: path-scoped suggestions, explicit path_prefix wins (#101)

### DIFF
--- a/backend/news/101.bugfix
+++ b/backend/news/101.bugfix
@@ -1,0 +1,1 @@
+@solr-suggest accepts an optional path_prefix (path_parents filter), so livesearch suggestions honor a subtree scope like the search results do. @reebalazs

--- a/backend/src/kitconcept/solr/services/suggest.py
+++ b/backend/src/kitconcept/solr/services/suggest.py
@@ -58,6 +58,13 @@ class SolrSuggest(Service):
         if lang:
             d["fq"] = d["fq"] + ["Language:(" + escape(lang) + ")"]
 
+        # Optional path scoping: restricts suggestions to a subtree,
+        # e.g. a subsite or workspace, matching the local search.
+        if path_prefix := self.request.form.get("path_prefix", "").strip():
+            portal_path = "/".join(api.portal.get().getPhysicalPath())
+            prefix = portal_path + path_prefix.rstrip("/")
+            d["fq"] = d["fq"] + [f'path_parents:"{prefix}"']
+
         d["fq"] = " AND ".join(d["fq"])
         querystring = urllib.parse.urlencode(d)
         url = "{}/{}".format(connection.solrBase, f"suggest?{querystring}")

--- a/backend/tests/services/suggest/test_suggest.py
+++ b/backend/tests/services/suggest/test_suggest.py
@@ -91,3 +91,13 @@ class TestSuggestDefaultBaseSearch(TestSuggestDefault):
             get_suggest_result_props(expected_dict).items()
             <= get_suggest_result_props(get_suggest_item(self.data, index)).items()
         )
+
+
+class TestSuggestPathPrefix(TestSuggestDefault):
+    """path_prefix restricts suggestions to a subtree (e.g. a workspace)."""
+
+    url = "/@solr-suggest?query=chomsky&path_prefix=/mydocument"
+
+    def test_only_prefixed_results(self, get_suggest_result_path):
+        paths = [get_suggest_result_path(item) for item in self.data["suggestions"]]
+        assert paths == ["/plone/mydocument"]

--- a/frontend/packages/volto-solr/news/101.bugfix
+++ b/frontend/packages/volto-solr/news/101.bugfix
@@ -1,0 +1,1 @@
+Local search fixes: @solr-suggest accepts an optional path_prefix so suggestions honor a subtree scope, and an explicit path_prefix URL param wins over the getPathPrefix heuristic, which silently dropped top-level (single-segment) prefixes. @reebalazs

--- a/frontend/packages/volto-solr/src/actions/solrsearch/solrSearchSuggestions.js
+++ b/frontend/packages/volto-solr/src/actions/solrsearch/solrSearchSuggestions.js
@@ -1,11 +1,21 @@
 export const GET_SOLR_SEARCH_SUGGESTIONS = 'GET_SOLR_SEARCH_SUGGESTIONS';
 
-export function solrSearchSuggestions(term) {
+/**
+ * Fetch live search suggestions.
+ * @param {string} term The (url-encoded) search term.
+ * @param {string=} pathPrefix Optional path to restrict the suggestions
+ * to a subtree (e.g. a subsite or workspace).
+ */
+export function solrSearchSuggestions(term, pathPrefix) {
+  const params = [`query=${term}`];
+  if (pathPrefix) {
+    params.push(`path_prefix=${encodeURIComponent(pathPrefix)}`);
+  }
   return {
     type: GET_SOLR_SEARCH_SUGGESTIONS,
     request: {
       op: 'get',
-      path: `/@solr-suggest?query=${term}`,
+      path: `/@solr-suggest?${params.join('&')}`,
     },
   };
 }

--- a/frontend/packages/volto-solr/src/components/theme/SolrSearch/SolrSearch.jsx
+++ b/frontend/packages/volto-solr/src/components/theme/SolrSearch/SolrSearch.jsx
@@ -269,10 +269,17 @@ class SolrSearch extends Component {
       ...params,
       sort_on: params.sort_on !== 'relevance' ? params.sort_on : '',
       b_start: (this.state.currentPage - 1) * config.settings.defaultPageSize,
-      path_prefix: getPathPrefix(window.location),
+      path_prefix: this.searchPathPrefix(params),
       doEmptySearch: this.props.doEmptySearch,
     });
   };
+
+  // An explicit path_prefix URL param wins over the URL heuristic:
+  // getPathPrefix treats every single-segment path as a language root
+  // (/de, /en), so a top-level subsite or workspace (/my-workspace)
+  // would silently lose its prefix.
+  searchPathPrefix = (params) =>
+    params.path_prefix || getPathPrefix(window.location);
 
   updateSearch = () => {
     this.props.history.replace({


### PR DESCRIPTION
Fixes #101 (items 1 and 2). Port of the local-scoping fixes from the `feature-ai-rag` line (#100), without the AI-search parts:

- `@solr-suggest` accepts an optional `path_prefix` and filters with `path_parents`, so livesearch suggestions honor a subtree scope like the search results do (integration test included; `pathPrefix` argument on the `solrSearchSuggestions` action, backward compatible).
- `searchPathPrefix()`: an explicit `path_prefix` URL param wins over the `getPathPrefix` heuristic, which treats every single-segment path as a language root (`/de`, `/en`) and silently dropped the prefix for top-level subsites/workspaces.

Item 3 of #101 (multilingual handling neutralizing `path_prefix` on sites without plone.app.multilingual) remains open.

**Not to be merged yet** — queued for the release line together with #96 and #99.