### PR TITLE
Local (subtree) scoping for suggest and AI search (#79)

### DIFF
--- a/backend/news/+local-scope-suggest.feature
+++ b/backend/news/+local-scope-suggest.feature
@@ -1,0 +1,1 @@
+@solr-suggest accepts an optional path_prefix (path_parents filter, same pattern as the RAG retrieval), so livesearch suggestions honor a subtree scope like the search results do. @reebalazs

--- a/backend/src/kitconcept/solr/services/suggest.py
+++ b/backend/src/kitconcept/solr/services/suggest.py
@@ -58,6 +58,13 @@ class SolrSuggest(Service):
         if lang:
             d["fq"] = d["fq"] + ["Language:(" + escape(lang) + ")"]
 
+        # Optional path scoping (same pattern as the RAG retrieval):
+        # restricts suggestions to a subtree, e.g. the current workspace.
+        if path_prefix := self.request.form.get("path_prefix", "").strip():
+            portal_path = "/".join(api.portal.get().getPhysicalPath())
+            prefix = portal_path + path_prefix.rstrip("/")
+            d["fq"] = d["fq"] + [f'path_parents:"{prefix}"']
+
         d["fq"] = " AND ".join(d["fq"])
         querystring = urllib.parse.urlencode(d)
         url = "{}/{}".format(connection.solrBase, f"suggest?{querystring}")

--- a/backend/tests/services/suggest/test_suggest.py
+++ b/backend/tests/services/suggest/test_suggest.py
@@ -91,3 +91,13 @@ class TestSuggestDefaultBaseSearch(TestSuggestDefault):
             get_suggest_result_props(expected_dict).items()
             <= get_suggest_result_props(get_suggest_item(self.data, index)).items()
         )
+
+
+class TestSuggestPathPrefix(TestSuggestDefault):
+    """path_prefix restricts suggestions to a subtree (e.g. a workspace)."""
+
+    url = "/@solr-suggest?query=chomsky&path_prefix=/mydocument"
+
+    def test_only_prefixed_results(self, get_suggest_result_path):
+        paths = [get_suggest_result_path(item) for item in self.data["suggestions"]]
+        assert paths == ["/plone/mydocument"]

--- a/frontend/packages/volto-solr/news/+local-scope.feature
+++ b/frontend/packages/volto-solr/news/+local-scope.feature
@@ -1,0 +1,1 @@
+Local (subtree) scoping across the search stack: @solr-suggest accepts path_prefix (same path_parents pattern as the RAG retrieval), the ragSearch and solrSearchSuggestions actions take an optional pathPrefix, and a local search on the search page also scopes the AI retrieval so the answer's grounding matches the classic results. @reebalazs

--- a/frontend/packages/volto-solr/src/actions/ragsearch/ragsearch.js
+++ b/frontend/packages/volto-solr/src/actions/ragsearch/ragsearch.js
@@ -18,12 +18,18 @@ export const RESET_RAG_SEARCH = 'RESET_RAG_SEARCH';
  * @param {string} question The natural language question.
  * @returns {Object} RAG search action.
  */
-export function ragSearch(url, question) {
+export function ragSearch(url, question, pathPrefix) {
+  const params = [`q=${encodeURIComponent(question)}`];
+  if (pathPrefix) {
+    // Restrict retrieval (and thus the answer's grounding) to a
+    // subtree, e.g. the current workspace.
+    params.push(`path_prefix=${encodeURIComponent(pathPrefix)}`);
+  }
   return {
     type: RAG_SEARCH,
     request: {
       op: 'get',
-      path: `${url}/@rag-search?q=${encodeURIComponent(question)}`,
+      path: `${url}/@rag-search?${params.join('&')}`,
     },
   };
 }

--- a/frontend/packages/volto-solr/src/actions/solrsearch/solrSearchSuggestions.js
+++ b/frontend/packages/volto-solr/src/actions/solrsearch/solrSearchSuggestions.js
@@ -1,11 +1,21 @@
 export const GET_SOLR_SEARCH_SUGGESTIONS = 'GET_SOLR_SEARCH_SUGGESTIONS';
 
-export function solrSearchSuggestions(term) {
+/**
+ * Fetch live search suggestions.
+ * @param {string} term The (url-encoded) search term.
+ * @param {string=} pathPrefix Optional path to restrict the suggestions
+ * to a subtree (e.g. the current workspace).
+ */
+export function solrSearchSuggestions(term, pathPrefix) {
+  const params = [`query=${term}`];
+  if (pathPrefix) {
+    params.push(`path_prefix=${encodeURIComponent(pathPrefix)}`);
+  }
   return {
     type: GET_SOLR_SEARCH_SUGGESTIONS,
     request: {
       op: 'get',
-      path: `/@solr-suggest?query=${term}`,
+      path: `/@solr-suggest?${params.join('&')}`,
     },
   };
 }

--- a/frontend/packages/volto-solr/src/components/theme/SolrSearch/SolrSearch.jsx
+++ b/frontend/packages/volto-solr/src/components/theme/SolrSearch/SolrSearch.jsx
@@ -278,16 +278,29 @@ class SolrSearch extends Component {
     // goes to the RAG endpoint: the AI answer renders above the
     // classic result list, it does not replace it
     if (this.props.ragAvailable && this.state.useAI && params.SearchableText) {
-      this.props.ragSearch('', params.SearchableText);
+      // Local search also scopes the AI retrieval, so the answer's
+      // grounding matches the classic result list.
+      const ragPathPrefix =
+        (params.local || '').toLowerCase() === 'true'
+          ? this.searchPathPrefix(params)
+          : undefined;
+      this.props.ragSearch('', params.SearchableText, ragPathPrefix);
     }
     this.props.searchContent('', {
       ...params,
       sort_on: params.sort_on !== 'relevance' ? params.sort_on : '',
       b_start: (this.state.currentPage - 1) * config.settings.defaultPageSize,
-      path_prefix: getPathPrefix(window.location),
+      path_prefix: this.searchPathPrefix(params),
       doEmptySearch: this.props.doEmptySearch,
     });
   };
+
+  // An explicit path_prefix URL param wins over the URL heuristic:
+  // getPathPrefix treats every single-segment path as a language root
+  // (/de, /en), so a top-level subsite or workspace (/my-workspace)
+  // would silently lose its prefix.
+  searchPathPrefix = (params) =>
+    params.path_prefix || getPathPrefix(window.location);
 
   // RAG: TESTING
   setUseAI = (checked) => {


### PR DESCRIPTION
Revival of #100 (closed yesterday to keep local/global out of that delivery), rebased onto the current `feature-ai-rag`. Consumed by the kitconcept.intranet workspace search dialog (internal ticket #426), where the Workspace chip acts as the local/global scope switch.

- `@solr-suggest` accepts an optional `path_prefix` and filters with the same `path_parents` pattern the RAG retrieval already uses — **integration test included** (`TestSuggestPathPrefix`).
- `ragSearch` and `solrSearchSuggestions` actions take an optional `pathPrefix` argument (backward compatible).
- On the search page, a local search (`local=true`) passes the path prefix to the AI retrieval too, so the answer's grounding matches the classic result list (`@rag-search` already supported `path_prefix`).
- `searchPathPrefix()`: an explicit `path_prefix` URL param wins over the `getPathPrefix` heuristic, which treats every single-segment path as a language root and silently dropped the prefix for top-level workspaces.

Without `pathPrefix`/`path_prefix` nothing changes for existing consumers.

The intranet-side consumer (dialog scope switch + Cypress/unit tests) follows in a kitconcept.intranet PR that depends on this merge + a pin bump.