### PR TITLE
Suggest: do not embed the child listing of folderish suggestions (#105)

### DIFF
--- a/backend/news/105.bugfix
+++ b/backend/news/105.bugfix
@@ -1,0 +1,1 @@
+Suggest: pass `include_items=False` when serializing a suggestion in full. For folderish portal types plone.restapi would otherwise run an extra catalog query per suggestion and embed the entire child listing into the type-ahead response. @reebalazs

--- a/backend/src/kitconcept/solr/services/suggest.py
+++ b/backend/src/kitconcept/solr/services/suggest.py
@@ -14,6 +14,11 @@ import json
 import urllib
 
 
+# Portal types serialized in full instead of from the catalog brain, because
+# the suggest dropdown renders more than title and type for them.
+FULL_SERIALIZATION_TYPES = ("Member",)
+
+
 class SolrSuggest(Service):
     def _language_settings(self) -> tuple[bool, str]:
         lang = self.request.form.get("lang")
@@ -70,9 +75,16 @@ class SolrSuggest(Service):
         return data
 
     def serialize_brain(self, brain):
-        if brain["portal_type"] in ["Member"]:
+        if brain["portal_type"] in FULL_SERIALIZATION_TYPES:
             obj = brain.getObject()
-            data = getMultiAdapter((obj, self.request), ISerializeToJson)()
+            # `include_items=False` matters for folderish types: plone.restapi
+            # picks SerializeFolderToJson for them, which would otherwise run a
+            # catalog query per suggestion and embed the whole child listing in
+            # the response. The plain SerializeToJson accepts and ignores the
+            # keyword, so no type check is needed here.
+            data = getMultiAdapter((obj, self.request), ISerializeToJson)(
+                include_items=False
+            )
             data["@id"] = obj.absolute_url()
             return data
 

--- a/backend/tests/services/suggest/test_suggest_serialize_brain.py
+++ b/backend/tests/services/suggest/test_suggest_serialize_brain.py
@@ -1,0 +1,75 @@
+"""Serialization of individual suggestions.
+
+These tests do not need Solr: they exercise `serialize_brain()` directly, so
+they only request the `integration` fixture and never the Solr-backed `portal`
+fixture from the enclosing conftest.
+
+`Document` stands in for the folderish suggest type here. With plone.volto
+applied it is a Dexterity `Container`, so plone.restapi serializes it with
+`SerializeFolderToJson` - exactly the situation that makes the child listing
+leak into the suggest payload.
+"""
+
+from kitconcept.solr.services import suggest as suggest_module
+from kitconcept.solr.services.suggest import SolrSuggest
+from plone import api
+
+import pytest
+
+
+@pytest.fixture
+def service(integration):
+    service = SolrSuggest()
+    service.context = integration["portal"]
+    service.request = integration["request"]
+    return service
+
+
+@pytest.fixture
+def folderish_brain(integration):
+    """A brain for a folderish object that has a child."""
+    portal = integration["portal"]
+    with api.env.adopt_roles(["Manager"]):
+        parent = api.content.create(
+            container=portal, type="Document", id="a-parent", title="A Parent"
+        )
+        api.content.create(
+            container=parent, type="Document", id="a-child", title="A Child"
+        )
+    return api.content.find(UID=parent.UID())[0]
+
+
+@pytest.fixture
+def serialize_document_in_full(monkeypatch):
+    monkeypatch.setattr(suggest_module, "FULL_SERIALIZATION_TYPES", ("Document",))
+
+
+class TestSerializeBrain:
+    def test_summary_serialization_is_the_default(self, service, folderish_brain):
+        data = service.serialize_brain(folderish_brain)
+
+        # The summary serializer does not report folderishness at all, which is
+        # how we know the full serializer was not used here.
+        assert "is_folderish" not in data
+        assert "items" not in data
+
+    def test_full_serialization_omits_the_child_listing(
+        self, service, folderish_brain, serialize_document_in_full
+    ):
+        data = service.serialize_brain(folderish_brain)
+
+        # We really did go through SerializeFolderToJson ...
+        assert data["is_folderish"] is True
+        # ... but none of its expensive extras made it into the payload.
+        assert "items" not in data
+        assert "items_total" not in data
+        assert "batching" not in data
+
+    def test_full_serialization_still_returns_the_object(
+        self, service, folderish_brain, serialize_document_in_full
+    ):
+        data = service.serialize_brain(folderish_brain)
+
+        assert data["@id"].endswith("/a-parent")
+        assert data["@type"] == "Document"
+        assert data["title"] == "A Parent"


### PR DESCRIPTION
Fixes #105.

## What

`SolrSuggest.serialize_brain()` serializes a small set of portal types in full
via `ISerializeToJson` rather than from the catalog brain. For any Dexterity
**container**, plone.restapi resolves that to `SerializeFolderToJson`, which
defaults to `include_items=True`. So for a folderish suggest type, every single
suggestion:

1. ran an extra catalog query over that object's children, and
2. carried the complete child listing (`items`, `items_total`, `batching`) in
   the response.

Nothing in the suggest UI consumes those keys — it renders a title, a type and
a link.

## Why it matters

Suggest is a **type-ahead** endpoint: it fires on nearly every keystroke, and
the cost multiplies by `keystrokes x suggestions`. It degrades exactly the
interaction that is supposed to feel instant, and it does so silently — no
error, no log entry, just a fat response and extra catalog work per request.

The `Member` branch is not dead code; the frontend has a matching render branch
in `SolrSearchWidget.jsx`. And folderish suggest types are not exotic:
`collective.person`'s `Person` **is** a `Container` (it accepts `File` and
`Image` children), so a person-directory intranet that surfaces people in the
suggest dropdown lands here directly, with the payload growing with each
attachment on each person.

## How

Pass `include_items=False` explicitly. Plain `SerializeToJson` accepts and
ignores the keyword, so the call stays correct for both folderish and
non-folderish types — no type check needed, and non-folderish types are
completely unaffected.

The inline `["Member"]` literal is lifted into a module-level
`FULL_SERIALIZATION_TYPES` constant. That names the behaviour, and it lets the
test cover the folderish path without adding a `Member` content type to the
fixtures.

## Tests

New `backend/tests/services/suggest/test_suggest_serialize_brain.py`, three
cases. They exercise `serialize_brain()` directly and only request the
`integration` fixture, so **they need no running Solr** despite living under
`tests/services/suggest/`.

`Document` stands in for the folderish suggest type: with plone.volto applied
it is a `Container`, so it genuinely routes through `SerializeFolderToJson` —
the first assertion (`is_folderish is True`) pins that down, so the
"no items" assertions cannot pass vacuously.

Verified the test actually catches the bug: reverting just the
`include_items=False` argument makes `test_full_serialization_omits_the_child_listing`
fail on `assert "items" not in data`. With the fix, all three pass.

## Note / known limitation

`SerializeFolderToJson` lets the request override the keyword:

```python
include_items = self.request.form.get("include_items", include_items)
```

So `/@solr-suggest?query=x&include_items=true` still returns the items. That is
a caller opting in explicitly rather than an accidental default, so this PR
does not defend against it — recording it here so it is not a surprise later.

## Scope

Small and self-contained; no API change for any existing consumer. Intended for
the batch of small fixes going into the upcoming release candidate — **please
review independently, not to be merged as part of anything else.**
