### PR TITLE
Do not override solr-update-core-and-start in the compose files (feature-ai-rag)

### DIFF
--- a/docker-compose-ci.yml
+++ b/docker-compose-ci.yml
@@ -22,9 +22,7 @@ services:
     ports:
       - 8983:8983
     command:
-      - solr-precreate
-      - plone
-      - /plone-config
+      - solr-update-core-and-start
     environment:
       SOLR_MODULES: extraction
       SOLR_OPTS: "-Dsolr.tika.url=http://tika-acceptance:9998"

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -19,9 +19,7 @@ services:
     ports:
       - 8983:8983
     command:
-      - solr-precreate
-      - plone
-      - /plone-config
+      - solr-update-core-and-start
     environment:
       SOLR_MODULES: extraction
       SOLR_OPTS: "-Dsolr.tika.url=http://tika-acceptance:9998"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -114,9 +114,7 @@ services:
     depends_on:
       - tika
     command:
-      - solr-precreate
-      - plone
-      - /plone-config
+      - solr-update-core-and-start
     environment:
       SOLR_MODULES: extraction
       SOLR_OPTS: "-Dsolr.tika.url=http://tika:9998"

--- a/news/107.bugfix
+++ b/news/107.bugfix
@@ -1,0 +1,1 @@
+Remove config files from an existing Solr core when they are removed from the image. @reekitconcept

--- a/news/107.internal
+++ b/news/107.internal
@@ -1,0 +1,1 @@
+Stop overriding the image `CMD` with `solr-precreate` in the compose files. @reekitconcept

--- a/solr/bin/solr-update-core-and-start
+++ b/solr/bin/solr-update-core-and-start
@@ -5,8 +5,13 @@
 # Update conf files in existing solr core (if present).
 # Then run solr-precreate which creates the core (if not present)
 # and starts solr.
+#
+# conf is dropped first so that a config file removed from the image is
+# also removed from the core; cp alone would leave it behind forever.
+# Only conf is touched, the index in data is left alone.
 
 if [ -d /var/solr/data/plone ]; then
+  rm -rf /var/solr/data/plone/conf
   cp -r /plone-config/* /var/solr/data/plone
 fi
 


### PR DESCRIPTION
Refs #107 — same change as #108, applied to `feature-ai-rag` since that branch goes in after the impending release and the intranet stacks default to `SOLR_TAG=feature-ai-rag`.

The image sets `CMD ["solr-update-core-and-start"]`, which refreshes the config of an already existing core before calling `solr-precreate`. The compose files override it with a `command:` of plain `solr-precreate`, disabling the refresh, so an existing core keeps its old config.

Call the script explicitly instead of relying on the CMD, and drop `conf` before copying so removed config files are removed from the core too. Only `conf` is touched, the index in `data` survives.